### PR TITLE
feature: Support enum with named field.

### DIFF
--- a/macro/src/snapshots/rust_sitter_macro__tests__enum_with_named_field.snap
+++ b/macro/src/snapshots/rust_sitter_macro__tests__enum_with_named_field.snap
@@ -1,0 +1,70 @@
+---
+source: macro/src/lib.rs
+expression: "rustfmt_code(&expand_grammar(parse_quote! {\n                            #[rust_sitter :: grammar(\"test\")] mod grammar\n                            {\n                                #[rust_sitter :: language] pub enum Expr\n                                {\n                                    Number(#[rust_sitter ::\n                                    leaf(pattern = r\"\\d+\", transform = | v |\n                                    v.parse().unwrap())] u32), Neg\n                                    {\n                                        #[rust_sitter :: leaf(text = \"!\")] _bang : (), value : Box <\n                                        Expr >,\n                                    }\n                                }\n                            }\n                        }).to_token_stream().to_string())"
+---
+mod grammar {
+    pub enum Expr {
+        Number(u32),
+        Neg { _bang: (), value: Box<Expr> },
+    }
+    impl rust_sitter::Extract for Expr {
+        #[allow(non_snake_case)]
+        fn extract(node: rust_sitter::Node, source: &[u8]) -> Self {
+            #[allow(non_snake_case)]
+            #[allow(clippy::unused_unit)]
+            fn extract_Expr_Number_0(node: Option<rust_sitter::Node>, source: &[u8]) -> u32 {
+                fn make_transform() -> impl Fn(&str) -> u32 {
+                    |v| v.parse().unwrap()
+                }
+                make_transform()(node.and_then(|n| n.utf8_text(source).ok()).unwrap())
+            }
+            #[allow(non_snake_case)]
+            fn extract_Expr_Number(node: rust_sitter::Node, source: &[u8]) -> Expr {
+                Expr::Number(extract_Expr_Number_0(node.child_by_field_name("0"), source))
+            }
+            #[allow(non_snake_case)]
+            #[allow(clippy::unused_unit)]
+            fn extract_Expr_Neg__bang(node: Option<rust_sitter::Node>, source: &[u8]) -> () {
+                ()
+            }
+            #[allow(non_snake_case)]
+            #[allow(clippy::unused_unit)]
+            fn extract_Expr_Neg_value(node: Option<rust_sitter::Node>, source: &[u8]) -> Box<Expr> {
+                Box::new(Expr::extract(node.unwrap(), source))
+            }
+            #[allow(non_snake_case)]
+            fn extract_Expr_Neg(node: rust_sitter::Node, source: &[u8]) -> Expr {
+                Expr::Neg {
+                    _bang: extract_Expr_Neg__bang(node.child_by_field_name("_bang"), source),
+                    value: extract_Expr_Neg_value(node.child_by_field_name("value"), source),
+                }
+            }
+            match node.child(0).unwrap().kind() {
+                "Expr_Number" => extract_Expr_Number(node.child(0).unwrap(), source),
+                "Expr_Neg" => extract_Expr_Neg(node.child(0).unwrap(), source),
+                _ => panic!(),
+            }
+        }
+    }
+    extern "C" {
+        fn tree_sitter_test() -> rust_sitter::Language;
+    }
+    fn language() -> rust_sitter::Language {
+        unsafe { tree_sitter_test() }
+    }
+    pub fn parse(input: &str) -> core::result::Result<Expr, Vec<rust_sitter::errors::ParseError>> {
+        let mut parser = rust_sitter::Parser::new();
+        parser.set_language(language()).unwrap();
+        let tree = parser.parse(input, None).unwrap();
+        let root_node = tree.root_node();
+        if root_node.has_error() {
+            let mut errors = vec![];
+            rust_sitter::errors::collect_parsing_errors(&root_node, input.as_bytes(), &mut errors);
+            Err(errors)
+        } else {
+            use rust_sitter::Extract;
+            Ok(Expr::extract(root_node, input.as_bytes()))
+        }
+    }
+}
+

--- a/tool/src/lib.rs
+++ b/tool/src/lib.rs
@@ -461,6 +461,33 @@ mod tests {
     use super::generate_grammar;
 
     #[test]
+    fn enum_with_named_field() {
+        let m = if let syn::Item::Mod(m) = parse_quote! {
+            #[rust_sitter::grammar("test")]
+            mod grammar {
+                #[rust_sitter::language]
+                pub enum Expr {
+                    Number(
+                            #[rust_sitter::leaf(pattern = r"\d+", transform = |v| v.parse().unwrap())]
+                            u32
+                    ),
+                    Neg {
+                        #[rust_sitter::leaf(text = "!")]
+                        _bang: (),
+                        value: Box<Expr>,
+                    }
+                }
+            }
+        } {
+            m
+        } else {
+            panic!()
+        };
+
+        insta::assert_display_snapshot!(generate_grammar(&m));
+    }
+
+    #[test]
     fn enum_transformed_fields() {
         let m = if let syn::Item::Mod(m) = parse_quote! {
             #[rust_sitter::grammar("test")]

--- a/tool/src/snapshots/rust_sitter_tool__tests__enum_with_named_field.snap
+++ b/tool/src/snapshots/rust_sitter_tool__tests__enum_with_named_field.snap
@@ -1,0 +1,5 @@
+---
+source: tool/src/lib.rs
+expression: generate_grammar(&m)
+---
+{"name":"test","rules":{"source_file":{"type":"CHOICE","members":[{"type":"SYMBOL","name":"Expr_Number"},{"type":"SYMBOL","name":"Expr_Neg"}]},"Expr_Number_0":{"type":"PATTERN","value":"\\d+"},"Expr_Number":{"type":"SEQ","members":[{"type":"FIELD","name":"0","content":{"type":"SYMBOL","name":"Expr_Number_0"}}]},"Expr_Neg__bang":{"type":"STRING","value":"!"},"Expr_Neg":{"type":"SEQ","members":[{"type":"FIELD","name":"_bang","content":{"type":"SYMBOL","name":"Expr_Neg__bang"}},{"type":"FIELD","name":"value","content":{"type":"SYMBOL","name":"Expr"}}]},"Expr":{"type":"CHOICE","members":[{"type":"SYMBOL","name":"Expr_Number"},{"type":"SYMBOL","name":"Expr_Neg"}]}},"extras":[]}


### PR DESCRIPTION
I got an error for enum with named field:

```
error: custom attribute panicked
 --> src/example.rs:1:1
  |
1 | #[rust_sitter::grammar("example")]
  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  |
  = help: message: expected `,`
```

This PR add support for enum with named field:

```rust
#[rust_sitter::grammar("example")]
pub mod grammar {
		#[rust_sitter::language]
		#[derive(Debug)]
		pub enum Expr {
			Number(
					#[rust_sitter::leaf(pattern = r"\d+", transform = |v| v.parse().unwrap())]
					u32
			),
			Neg {
				#[rust_sitter::leaf(text = "!")]
				_bang: (),
				value: Box<Expr>,
			}
		}
}
```

With this change I can parse successfully:

```shell
[src/main.rs:6] example::grammar::parse("!1") = Ok(
    Neg {
        _bang: (),
        value: Number(
            1,
        ),
    },
)
```
