### PR TITLE
feature: Add Support for enum with unnamed vector field.

### DIFF
--- a/macro/src/snapshots/rust_sitter_macro__tests__enum_with_unamed_vector.snap
+++ b/macro/src/snapshots/rust_sitter_macro__tests__enum_with_unamed_vector.snap
@@ -1,0 +1,78 @@
+---
+source: macro/src/lib.rs
+expression: "rustfmt_code(&expand_grammar(parse_quote! {\n                            #[rust_sitter :: grammar(\"test\")] mod grammar\n                            {\n                                pub struct Number\n                                {\n                                    #[rust_sitter ::\n                                    leaf(pattern = r\"\\d+\", transform = | v |\n                                    v.parse().unwrap())] value : u32\n                                } #[rust_sitter :: language] pub enum Expr\n                                {\n                                    Numbers(#[rust_sitter :: repeat(non_empty = true)] Vec <\n                                    Number >)\n                                }\n                            }\n                        }).to_token_stream().to_string())"
+---
+mod grammar {
+    pub struct Number {
+        value: u32,
+    }
+    impl rust_sitter::Extract for Number {
+        #[allow(non_snake_case)]
+        fn extract(node: rust_sitter::Node, source: &[u8]) -> Self {
+            #[allow(non_snake_case)]
+            #[allow(clippy::unused_unit)]
+            fn extract_Number_value(node: Option<rust_sitter::Node>, source: &[u8]) -> u32 {
+                fn make_transform() -> impl Fn(&str) -> u32 {
+                    |v| v.parse().unwrap()
+                }
+                make_transform()(node.and_then(|n| n.utf8_text(source).ok()).unwrap())
+            }
+            #[allow(non_snake_case)]
+            fn extract_Number(node: rust_sitter::Node, source: &[u8]) -> Number {
+                Number {
+                    value: extract_Number_value(node.child_by_field_name("value"), source),
+                }
+            }
+            extract_Number(node, source)
+        }
+    }
+    pub enum Expr {
+        Numbers(Vec<Number>),
+    }
+    impl rust_sitter::Extract for Expr {
+        #[allow(non_snake_case)]
+        fn extract(node: rust_sitter::Node, source: &[u8]) -> Self {
+            #[allow(non_snake_case)]
+            #[allow(clippy::unused_unit)]
+            fn extract_Expr_Numbers_0(
+                node: Option<rust_sitter::Node>,
+                source: &[u8],
+            ) -> Vec<Number> {
+                let node = node.unwrap();
+                let mut cursor = node.walk();
+                node.children_by_field_name("0", &mut cursor)
+                    .map(|n| Number::extract(n, source))
+                    .collect::<Vec<Number>>()
+            }
+            #[allow(non_snake_case)]
+            fn extract_Expr_Numbers(node: rust_sitter::Node, source: &[u8]) -> Expr {
+                Expr::Numbers(extract_Expr_Numbers_0(Some(node), source))
+            }
+            match node.child(0).unwrap().kind() {
+                "Expr_Numbers" => extract_Expr_Numbers(node.child(0).unwrap(), source),
+                _ => panic!(),
+            }
+        }
+    }
+    extern "C" {
+        fn tree_sitter_test() -> rust_sitter::Language;
+    }
+    fn language() -> rust_sitter::Language {
+        unsafe { tree_sitter_test() }
+    }
+    pub fn parse(input: &str) -> core::result::Result<Expr, Vec<rust_sitter::errors::ParseError>> {
+        let mut parser = rust_sitter::Parser::new();
+        parser.set_language(language()).unwrap();
+        let tree = parser.parse(input, None).unwrap();
+        let root_node = tree.root_node();
+        if root_node.has_error() {
+            let mut errors = vec![];
+            rust_sitter::errors::collect_parsing_errors(&root_node, input.as_bytes(), &mut errors);
+            Err(errors)
+        } else {
+            use rust_sitter::Extract;
+            Ok(Expr::extract(root_node, input.as_bytes()))
+        }
+    }
+}
+

--- a/tool/src/snapshots/rust_sitter_tool__tests__enum_with_unamed_vector.snap
+++ b/tool/src/snapshots/rust_sitter_tool__tests__enum_with_unamed_vector.snap
@@ -1,0 +1,5 @@
+---
+source: tool/src/lib.rs
+expression: generate_grammar(&m)
+---
+{"name":"test","rules":{"source_file":{"type":"CHOICE","members":[{"type":"SYMBOL","name":"Expr_Numbers"}]},"Number_value":{"type":"PATTERN","value":"\\d+"},"Number":{"type":"SEQ","members":[{"type":"FIELD","name":"value","content":{"type":"SYMBOL","name":"Number_value"}}]},"Expr_Numbers":{"type":"SEQ","members":[{"type":"REPEAT1","content":{"type":"FIELD","name":"0","content":{"type":"SYMBOL","name":"Number"}}}]},"Expr":{"type":"CHOICE","members":[{"type":"SYMBOL","name":"Expr_Numbers"}]}},"extras":[]}


### PR DESCRIPTION
I got an error with enum with unnamed vector field.

Code:
```rust
#[rust_sitter::grammar("example")]
pub mod grammar {
		#[derive(Debug)]
		pub struct Number {
				#[rust_sitter::leaf(pattern = r"\d+", transform = |v| v.parse().unwrap())]
				value: u32
		}

		#[rust_sitter::language]
		#[derive(Debug)]
		pub enum Expr {
			Numbers(
				#[rust_sitter::repeat(non_empty = true)]
				#[rust_sitter::delimited(
					#[rust_sitter::leaf(text = ",")]
					()
				)]
				Vec<Number>
			)
		}
}

```

```shell
  Caused by:
  process didn't exit successfully: `/Users/pocket7878/dev/src/github.com/pocket7878/rust-sitter-learning/target/debug/build/rust-sitter-learning-e9822a91dbcb63f1/build-script-build` (exit status: 101)
  --- stderr
  thread 'main' panicked at 'called `Option::unwrap()` on a `None` value', /Users/masato/dev/src/github.com/pocket7878/rust-sitter/tool/src/lib.rs:108:44
  stack backtrace:
     0: rust_begin_unwind
               at /rustc/4b91a6ea7258a947e59c6522cd5898e7c0a6a88f/library/std/src/panicking.rs:584:5
     1: core::panicking::panic_fmt
               at /rustc/4b91a6ea7258a947e59c6522cd5898e7c0a6a88f/library/core/src/panicking.rs:142:14
     2: core::panicking::panic
               at /rustc/4b91a6ea7258a947e59c6522cd5898e7c0a6a88f/library/core/src/panicking.rs:48:5
     3: core::option::Option<T>::unwrap
               at /rustc/4b91a6ea7258a947e59c6522cd5898e7c0a6a88f/library/core/src/option.rs:775:21
     4: rust_sitter_tool::gen_field
               at /Users/masato/dev/src/github.com/pocket7878/rust-sitter/tool/src/lib.rs:108:33
     5: rust_sitter_tool::gen_struct_or_variant::{{closure}}
               at /Users/masato/dev/src/github.com/pocket7878/rust-sitter/tool/src/lib.rs:201:34
```

This error is raised from here:
https://github.com/hydro-project/rust-sitter/blob/676cf5449009fc3477be7729870e57df4099e1fe/tool/src/lib.rs#L108

So this PR fixed this error by using field path as a fallback field_name if vector field is unnamed field.

With this fix I can successfully parse like this:

```rust
mod example;

fn main() {
    dbg!(example::grammar::parse("1,2,3")).expect("Failed to parse");
}
```

```shell
[src/main.rs:6] example::grammar::parse("1,2,3") = Ok(
    Numbers(
        [
            Number {
                value: 1,
            },
            Number {
                value: 2,
            },
            Number {
                value: 3,
            },
        ],
    ),
)
```