### PR TITLE
Move Tree Sitter re-export to a module of runtime

### DIFF
--- a/macro/src/snapshots/rust_sitter_macro__tests__enum_prec_left.snap
+++ b/macro/src/snapshots/rust_sitter_macro__tests__enum_prec_left.snap
@@ -9,12 +9,16 @@ mod grammar {
     }
     impl rust_sitter::Extract for Expression {
         #[allow(non_snake_case)]
-        fn extract(node: Option<rust_sitter::Node>, source: &[u8], last_idx: usize) -> Self {
+        fn extract(
+            node: Option<rust_sitter::tree_sitter::Node>,
+            source: &[u8],
+            last_idx: usize,
+        ) -> Self {
             let node = node.unwrap();
             #[allow(non_snake_case)]
             #[allow(clippy::unused_unit)]
             fn extract_Expression_Number_0(
-                cursor_opt: &mut Option<rust_sitter::TreeCursor>,
+                cursor_opt: &mut Option<rust_sitter::tree_sitter::TreeCursor>,
                 source: &[u8],
                 last_idx: &mut usize,
             ) -> i32 {
@@ -26,7 +30,7 @@ mod grammar {
                         let n = cursor.node();
                         if let Some(name) = cursor.field_name() {
                             if name == "0" {
-                                let node: Option<rust_sitter::Node> = Some(n);
+                                let node: Option<rust_sitter::tree_sitter::Node> = Some(n);
                                 let out = make_transform()(
                                     node.and_then(|n| n.utf8_text(source).ok()).unwrap(),
                                 );
@@ -36,7 +40,7 @@ mod grammar {
                                 *last_idx = n.end_byte();
                                 return out;
                             } else {
-                                let node: Option<rust_sitter::Node> = None;
+                                let node: Option<rust_sitter::tree_sitter::Node> = None;
                                 return make_transform()(
                                     node.and_then(|n| n.utf8_text(source).ok()).unwrap(),
                                 );
@@ -45,19 +49,22 @@ mod grammar {
                             *last_idx = n.end_byte();
                         }
                         if !cursor.goto_next_sibling() {
-                            let node: Option<rust_sitter::Node> = None;
+                            let node: Option<rust_sitter::tree_sitter::Node> = None;
                             return make_transform()(
                                 node.and_then(|n| n.utf8_text(source).ok()).unwrap(),
                             );
                         }
                     }
                 } else {
-                    let node: Option<rust_sitter::Node> = None;
+                    let node: Option<rust_sitter::tree_sitter::Node> = None;
                     return make_transform()(node.and_then(|n| n.utf8_text(source).ok()).unwrap());
                 }
             }
             #[allow(non_snake_case)]
-            fn extract_Expression_Number(node: rust_sitter::Node, source: &[u8]) -> Expression {
+            fn extract_Expression_Number(
+                node: rust_sitter::tree_sitter::Node,
+                source: &[u8],
+            ) -> Expression {
                 let mut last_idx = node.start_byte();
                 let mut parent_cursor = node.walk();
                 let mut cursor = if parent_cursor.goto_first_child() {
@@ -74,7 +81,7 @@ mod grammar {
             #[allow(non_snake_case)]
             #[allow(clippy::unused_unit)]
             fn extract_Expression_Sub_0(
-                cursor_opt: &mut Option<rust_sitter::TreeCursor>,
+                cursor_opt: &mut Option<rust_sitter::tree_sitter::TreeCursor>,
                 source: &[u8],
                 last_idx: &mut usize,
             ) -> Box<Expression> {
@@ -83,7 +90,7 @@ mod grammar {
                         let n = cursor.node();
                         if let Some(name) = cursor.field_name() {
                             if name == "0" {
-                                let node: Option<rust_sitter::Node> = Some(n);
+                                let node: Option<rust_sitter::tree_sitter::Node> = Some(n);
                                 let out = rust_sitter::Extract::extract(node, source, *last_idx);
                                 if !cursor.goto_next_sibling() {
                                     *cursor_opt = None;
@@ -91,26 +98,26 @@ mod grammar {
                                 *last_idx = n.end_byte();
                                 return out;
                             } else {
-                                let node: Option<rust_sitter::Node> = None;
+                                let node: Option<rust_sitter::tree_sitter::Node> = None;
                                 return rust_sitter::Extract::extract(node, source, *last_idx);
                             }
                         } else {
                             *last_idx = n.end_byte();
                         }
                         if !cursor.goto_next_sibling() {
-                            let node: Option<rust_sitter::Node> = None;
+                            let node: Option<rust_sitter::tree_sitter::Node> = None;
                             return rust_sitter::Extract::extract(node, source, *last_idx);
                         }
                     }
                 } else {
-                    let node: Option<rust_sitter::Node> = None;
+                    let node: Option<rust_sitter::tree_sitter::Node> = None;
                     return rust_sitter::Extract::extract(node, source, *last_idx);
                 }
             }
             #[allow(non_snake_case)]
             #[allow(clippy::unused_unit)]
             fn extract_Expression_Sub_1(
-                cursor_opt: &mut Option<rust_sitter::TreeCursor>,
+                cursor_opt: &mut Option<rust_sitter::tree_sitter::TreeCursor>,
                 source: &[u8],
                 last_idx: &mut usize,
             ) -> () {
@@ -119,7 +126,7 @@ mod grammar {
                         let n = cursor.node();
                         if let Some(name) = cursor.field_name() {
                             if name == "1" {
-                                let node: Option<rust_sitter::Node> = Some(n);
+                                let node: Option<rust_sitter::tree_sitter::Node> = Some(n);
                                 let out = rust_sitter::Extract::extract(node, source, *last_idx);
                                 if !cursor.goto_next_sibling() {
                                     *cursor_opt = None;
@@ -127,26 +134,26 @@ mod grammar {
                                 *last_idx = n.end_byte();
                                 return out;
                             } else {
-                                let node: Option<rust_sitter::Node> = None;
+                                let node: Option<rust_sitter::tree_sitter::Node> = None;
                                 return rust_sitter::Extract::extract(node, source, *last_idx);
                             }
                         } else {
                             *last_idx = n.end_byte();
                         }
                         if !cursor.goto_next_sibling() {
-                            let node: Option<rust_sitter::Node> = None;
+                            let node: Option<rust_sitter::tree_sitter::Node> = None;
                             return rust_sitter::Extract::extract(node, source, *last_idx);
                         }
                     }
                 } else {
-                    let node: Option<rust_sitter::Node> = None;
+                    let node: Option<rust_sitter::tree_sitter::Node> = None;
                     return rust_sitter::Extract::extract(node, source, *last_idx);
                 }
             }
             #[allow(non_snake_case)]
             #[allow(clippy::unused_unit)]
             fn extract_Expression_Sub_2(
-                cursor_opt: &mut Option<rust_sitter::TreeCursor>,
+                cursor_opt: &mut Option<rust_sitter::tree_sitter::TreeCursor>,
                 source: &[u8],
                 last_idx: &mut usize,
             ) -> Box<Expression> {
@@ -155,7 +162,7 @@ mod grammar {
                         let n = cursor.node();
                         if let Some(name) = cursor.field_name() {
                             if name == "2" {
-                                let node: Option<rust_sitter::Node> = Some(n);
+                                let node: Option<rust_sitter::tree_sitter::Node> = Some(n);
                                 let out = rust_sitter::Extract::extract(node, source, *last_idx);
                                 if !cursor.goto_next_sibling() {
                                     *cursor_opt = None;
@@ -163,24 +170,27 @@ mod grammar {
                                 *last_idx = n.end_byte();
                                 return out;
                             } else {
-                                let node: Option<rust_sitter::Node> = None;
+                                let node: Option<rust_sitter::tree_sitter::Node> = None;
                                 return rust_sitter::Extract::extract(node, source, *last_idx);
                             }
                         } else {
                             *last_idx = n.end_byte();
                         }
                         if !cursor.goto_next_sibling() {
-                            let node: Option<rust_sitter::Node> = None;
+                            let node: Option<rust_sitter::tree_sitter::Node> = None;
                             return rust_sitter::Extract::extract(node, source, *last_idx);
                         }
                     }
                 } else {
-                    let node: Option<rust_sitter::Node> = None;
+                    let node: Option<rust_sitter::tree_sitter::Node> = None;
                     return rust_sitter::Extract::extract(node, source, *last_idx);
                 }
             }
             #[allow(non_snake_case)]
-            fn extract_Expression_Sub(node: rust_sitter::Node, source: &[u8]) -> Expression {
+            fn extract_Expression_Sub(
+                node: rust_sitter::tree_sitter::Node,
+                source: &[u8],
+            ) -> Expression {
                 let mut last_idx = node.start_byte();
                 let mut parent_cursor = node.walk();
                 let mut cursor = if parent_cursor.goto_first_child() {
@@ -202,15 +212,15 @@ mod grammar {
         }
     }
     extern "C" {
-        fn tree_sitter_test() -> rust_sitter::Language;
+        fn tree_sitter_test() -> rust_sitter::tree_sitter::Language;
     }
-    fn language() -> rust_sitter::Language {
+    fn language() -> rust_sitter::tree_sitter::Language {
         unsafe { tree_sitter_test() }
     }
     pub fn parse(
         input: &str,
     ) -> core::result::Result<Expression, Vec<rust_sitter::errors::ParseError>> {
-        let mut parser = rust_sitter::Parser::new();
+        let mut parser = rust_sitter::tree_sitter::Parser::new();
         parser.set_language(language()).unwrap();
         let tree = parser.parse(input, None).unwrap();
         let root_node = tree.root_node();

--- a/macro/src/snapshots/rust_sitter_macro__tests__enum_recursive.snap
+++ b/macro/src/snapshots/rust_sitter_macro__tests__enum_recursive.snap
@@ -9,12 +9,16 @@ mod grammar {
     }
     impl rust_sitter::Extract for Expression {
         #[allow(non_snake_case)]
-        fn extract(node: Option<rust_sitter::Node>, source: &[u8], last_idx: usize) -> Self {
+        fn extract(
+            node: Option<rust_sitter::tree_sitter::Node>,
+            source: &[u8],
+            last_idx: usize,
+        ) -> Self {
             let node = node.unwrap();
             #[allow(non_snake_case)]
             #[allow(clippy::unused_unit)]
             fn extract_Expression_Number_0(
-                cursor_opt: &mut Option<rust_sitter::TreeCursor>,
+                cursor_opt: &mut Option<rust_sitter::tree_sitter::TreeCursor>,
                 source: &[u8],
                 last_idx: &mut usize,
             ) -> i32 {
@@ -26,7 +30,7 @@ mod grammar {
                         let n = cursor.node();
                         if let Some(name) = cursor.field_name() {
                             if name == "0" {
-                                let node: Option<rust_sitter::Node> = Some(n);
+                                let node: Option<rust_sitter::tree_sitter::Node> = Some(n);
                                 let out = make_transform()(
                                     node.and_then(|n| n.utf8_text(source).ok()).unwrap(),
                                 );
@@ -36,7 +40,7 @@ mod grammar {
                                 *last_idx = n.end_byte();
                                 return out;
                             } else {
-                                let node: Option<rust_sitter::Node> = None;
+                                let node: Option<rust_sitter::tree_sitter::Node> = None;
                                 return make_transform()(
                                     node.and_then(|n| n.utf8_text(source).ok()).unwrap(),
                                 );
@@ -45,19 +49,22 @@ mod grammar {
                             *last_idx = n.end_byte();
                         }
                         if !cursor.goto_next_sibling() {
-                            let node: Option<rust_sitter::Node> = None;
+                            let node: Option<rust_sitter::tree_sitter::Node> = None;
                             return make_transform()(
                                 node.and_then(|n| n.utf8_text(source).ok()).unwrap(),
                             );
                         }
                     }
                 } else {
-                    let node: Option<rust_sitter::Node> = None;
+                    let node: Option<rust_sitter::tree_sitter::Node> = None;
                     return make_transform()(node.and_then(|n| n.utf8_text(source).ok()).unwrap());
                 }
             }
             #[allow(non_snake_case)]
-            fn extract_Expression_Number(node: rust_sitter::Node, source: &[u8]) -> Expression {
+            fn extract_Expression_Number(
+                node: rust_sitter::tree_sitter::Node,
+                source: &[u8],
+            ) -> Expression {
                 let mut last_idx = node.start_byte();
                 let mut parent_cursor = node.walk();
                 let mut cursor = if parent_cursor.goto_first_child() {
@@ -74,7 +81,7 @@ mod grammar {
             #[allow(non_snake_case)]
             #[allow(clippy::unused_unit)]
             fn extract_Expression_Neg_0(
-                cursor_opt: &mut Option<rust_sitter::TreeCursor>,
+                cursor_opt: &mut Option<rust_sitter::tree_sitter::TreeCursor>,
                 source: &[u8],
                 last_idx: &mut usize,
             ) -> () {
@@ -83,7 +90,7 @@ mod grammar {
                         let n = cursor.node();
                         if let Some(name) = cursor.field_name() {
                             if name == "0" {
-                                let node: Option<rust_sitter::Node> = Some(n);
+                                let node: Option<rust_sitter::tree_sitter::Node> = Some(n);
                                 let out = rust_sitter::Extract::extract(node, source, *last_idx);
                                 if !cursor.goto_next_sibling() {
                                     *cursor_opt = None;
@@ -91,26 +98,26 @@ mod grammar {
                                 *last_idx = n.end_byte();
                                 return out;
                             } else {
-                                let node: Option<rust_sitter::Node> = None;
+                                let node: Option<rust_sitter::tree_sitter::Node> = None;
                                 return rust_sitter::Extract::extract(node, source, *last_idx);
                             }
                         } else {
                             *last_idx = n.end_byte();
                         }
                         if !cursor.goto_next_sibling() {
-                            let node: Option<rust_sitter::Node> = None;
+                            let node: Option<rust_sitter::tree_sitter::Node> = None;
                             return rust_sitter::Extract::extract(node, source, *last_idx);
                         }
                     }
                 } else {
-                    let node: Option<rust_sitter::Node> = None;
+                    let node: Option<rust_sitter::tree_sitter::Node> = None;
                     return rust_sitter::Extract::extract(node, source, *last_idx);
                 }
             }
             #[allow(non_snake_case)]
             #[allow(clippy::unused_unit)]
             fn extract_Expression_Neg_1(
-                cursor_opt: &mut Option<rust_sitter::TreeCursor>,
+                cursor_opt: &mut Option<rust_sitter::tree_sitter::TreeCursor>,
                 source: &[u8],
                 last_idx: &mut usize,
             ) -> Box<Expression> {
@@ -119,7 +126,7 @@ mod grammar {
                         let n = cursor.node();
                         if let Some(name) = cursor.field_name() {
                             if name == "1" {
-                                let node: Option<rust_sitter::Node> = Some(n);
+                                let node: Option<rust_sitter::tree_sitter::Node> = Some(n);
                                 let out = rust_sitter::Extract::extract(node, source, *last_idx);
                                 if !cursor.goto_next_sibling() {
                                     *cursor_opt = None;
@@ -127,24 +134,27 @@ mod grammar {
                                 *last_idx = n.end_byte();
                                 return out;
                             } else {
-                                let node: Option<rust_sitter::Node> = None;
+                                let node: Option<rust_sitter::tree_sitter::Node> = None;
                                 return rust_sitter::Extract::extract(node, source, *last_idx);
                             }
                         } else {
                             *last_idx = n.end_byte();
                         }
                         if !cursor.goto_next_sibling() {
-                            let node: Option<rust_sitter::Node> = None;
+                            let node: Option<rust_sitter::tree_sitter::Node> = None;
                             return rust_sitter::Extract::extract(node, source, *last_idx);
                         }
                     }
                 } else {
-                    let node: Option<rust_sitter::Node> = None;
+                    let node: Option<rust_sitter::tree_sitter::Node> = None;
                     return rust_sitter::Extract::extract(node, source, *last_idx);
                 }
             }
             #[allow(non_snake_case)]
-            fn extract_Expression_Neg(node: rust_sitter::Node, source: &[u8]) -> Expression {
+            fn extract_Expression_Neg(
+                node: rust_sitter::tree_sitter::Node,
+                source: &[u8],
+            ) -> Expression {
                 let mut last_idx = node.start_byte();
                 let mut parent_cursor = node.walk();
                 let mut cursor = if parent_cursor.goto_first_child() {
@@ -165,15 +175,15 @@ mod grammar {
         }
     }
     extern "C" {
-        fn tree_sitter_test() -> rust_sitter::Language;
+        fn tree_sitter_test() -> rust_sitter::tree_sitter::Language;
     }
-    fn language() -> rust_sitter::Language {
+    fn language() -> rust_sitter::tree_sitter::Language {
         unsafe { tree_sitter_test() }
     }
     pub fn parse(
         input: &str,
     ) -> core::result::Result<Expression, Vec<rust_sitter::errors::ParseError>> {
-        let mut parser = rust_sitter::Parser::new();
+        let mut parser = rust_sitter::tree_sitter::Parser::new();
         parser.set_language(language()).unwrap();
         let tree = parser.parse(input, None).unwrap();
         let root_node = tree.root_node();

--- a/macro/src/snapshots/rust_sitter_macro__tests__enum_transformed_fields.snap
+++ b/macro/src/snapshots/rust_sitter_macro__tests__enum_transformed_fields.snap
@@ -8,12 +8,16 @@ mod grammar {
     }
     impl rust_sitter::Extract for Expression {
         #[allow(non_snake_case)]
-        fn extract(node: Option<rust_sitter::Node>, source: &[u8], last_idx: usize) -> Self {
+        fn extract(
+            node: Option<rust_sitter::tree_sitter::Node>,
+            source: &[u8],
+            last_idx: usize,
+        ) -> Self {
             let node = node.unwrap();
             #[allow(non_snake_case)]
             #[allow(clippy::unused_unit)]
             fn extract_Expression_Number_0(
-                cursor_opt: &mut Option<rust_sitter::TreeCursor>,
+                cursor_opt: &mut Option<rust_sitter::tree_sitter::TreeCursor>,
                 source: &[u8],
                 last_idx: &mut usize,
             ) -> i32 {
@@ -25,7 +29,7 @@ mod grammar {
                         let n = cursor.node();
                         if let Some(name) = cursor.field_name() {
                             if name == "0" {
-                                let node: Option<rust_sitter::Node> = Some(n);
+                                let node: Option<rust_sitter::tree_sitter::Node> = Some(n);
                                 let out = make_transform()(
                                     node.and_then(|n| n.utf8_text(source).ok()).unwrap(),
                                 );
@@ -35,7 +39,7 @@ mod grammar {
                                 *last_idx = n.end_byte();
                                 return out;
                             } else {
-                                let node: Option<rust_sitter::Node> = None;
+                                let node: Option<rust_sitter::tree_sitter::Node> = None;
                                 return make_transform()(
                                     node.and_then(|n| n.utf8_text(source).ok()).unwrap(),
                                 );
@@ -44,19 +48,22 @@ mod grammar {
                             *last_idx = n.end_byte();
                         }
                         if !cursor.goto_next_sibling() {
-                            let node: Option<rust_sitter::Node> = None;
+                            let node: Option<rust_sitter::tree_sitter::Node> = None;
                             return make_transform()(
                                 node.and_then(|n| n.utf8_text(source).ok()).unwrap(),
                             );
                         }
                     }
                 } else {
-                    let node: Option<rust_sitter::Node> = None;
+                    let node: Option<rust_sitter::tree_sitter::Node> = None;
                     return make_transform()(node.and_then(|n| n.utf8_text(source).ok()).unwrap());
                 }
             }
             #[allow(non_snake_case)]
-            fn extract_Expression_Number(node: rust_sitter::Node, source: &[u8]) -> Expression {
+            fn extract_Expression_Number(
+                node: rust_sitter::tree_sitter::Node,
+                source: &[u8],
+            ) -> Expression {
                 let mut last_idx = node.start_byte();
                 let mut parent_cursor = node.walk();
                 let mut cursor = if parent_cursor.goto_first_child() {
@@ -77,15 +84,15 @@ mod grammar {
         }
     }
     extern "C" {
-        fn tree_sitter_test() -> rust_sitter::Language;
+        fn tree_sitter_test() -> rust_sitter::tree_sitter::Language;
     }
-    fn language() -> rust_sitter::Language {
+    fn language() -> rust_sitter::tree_sitter::Language {
         unsafe { tree_sitter_test() }
     }
     pub fn parse(
         input: &str,
     ) -> core::result::Result<Expression, Vec<rust_sitter::errors::ParseError>> {
-        let mut parser = rust_sitter::Parser::new();
+        let mut parser = rust_sitter::tree_sitter::Parser::new();
         parser.set_language(language()).unwrap();
         let tree = parser.parse(input, None).unwrap();
         let root_node = tree.root_node();

--- a/macro/src/snapshots/rust_sitter_macro__tests__enum_with_named_field.snap
+++ b/macro/src/snapshots/rust_sitter_macro__tests__enum_with_named_field.snap
@@ -9,12 +9,16 @@ mod grammar {
     }
     impl rust_sitter::Extract for Expr {
         #[allow(non_snake_case)]
-        fn extract(node: Option<rust_sitter::Node>, source: &[u8], last_idx: usize) -> Self {
+        fn extract(
+            node: Option<rust_sitter::tree_sitter::Node>,
+            source: &[u8],
+            last_idx: usize,
+        ) -> Self {
             let node = node.unwrap();
             #[allow(non_snake_case)]
             #[allow(clippy::unused_unit)]
             fn extract_Expr_Number_0(
-                cursor_opt: &mut Option<rust_sitter::TreeCursor>,
+                cursor_opt: &mut Option<rust_sitter::tree_sitter::TreeCursor>,
                 source: &[u8],
                 last_idx: &mut usize,
             ) -> u32 {
@@ -26,7 +30,7 @@ mod grammar {
                         let n = cursor.node();
                         if let Some(name) = cursor.field_name() {
                             if name == "0" {
-                                let node: Option<rust_sitter::Node> = Some(n);
+                                let node: Option<rust_sitter::tree_sitter::Node> = Some(n);
                                 let out = make_transform()(
                                     node.and_then(|n| n.utf8_text(source).ok()).unwrap(),
                                 );
@@ -36,7 +40,7 @@ mod grammar {
                                 *last_idx = n.end_byte();
                                 return out;
                             } else {
-                                let node: Option<rust_sitter::Node> = None;
+                                let node: Option<rust_sitter::tree_sitter::Node> = None;
                                 return make_transform()(
                                     node.and_then(|n| n.utf8_text(source).ok()).unwrap(),
                                 );
@@ -45,19 +49,19 @@ mod grammar {
                             *last_idx = n.end_byte();
                         }
                         if !cursor.goto_next_sibling() {
-                            let node: Option<rust_sitter::Node> = None;
+                            let node: Option<rust_sitter::tree_sitter::Node> = None;
                             return make_transform()(
                                 node.and_then(|n| n.utf8_text(source).ok()).unwrap(),
                             );
                         }
                     }
                 } else {
-                    let node: Option<rust_sitter::Node> = None;
+                    let node: Option<rust_sitter::tree_sitter::Node> = None;
                     return make_transform()(node.and_then(|n| n.utf8_text(source).ok()).unwrap());
                 }
             }
             #[allow(non_snake_case)]
-            fn extract_Expr_Number(node: rust_sitter::Node, source: &[u8]) -> Expr {
+            fn extract_Expr_Number(node: rust_sitter::tree_sitter::Node, source: &[u8]) -> Expr {
                 let mut last_idx = node.start_byte();
                 let mut parent_cursor = node.walk();
                 let mut cursor = if parent_cursor.goto_first_child() {
@@ -70,7 +74,7 @@ mod grammar {
             #[allow(non_snake_case)]
             #[allow(clippy::unused_unit)]
             fn extract_Expr_Neg__bang(
-                cursor_opt: &mut Option<rust_sitter::TreeCursor>,
+                cursor_opt: &mut Option<rust_sitter::tree_sitter::TreeCursor>,
                 source: &[u8],
                 last_idx: &mut usize,
             ) -> () {
@@ -79,7 +83,7 @@ mod grammar {
                         let n = cursor.node();
                         if let Some(name) = cursor.field_name() {
                             if name == "_bang" {
-                                let node: Option<rust_sitter::Node> = Some(n);
+                                let node: Option<rust_sitter::tree_sitter::Node> = Some(n);
                                 let out = rust_sitter::Extract::extract(node, source, *last_idx);
                                 if !cursor.goto_next_sibling() {
                                     *cursor_opt = None;
@@ -87,26 +91,26 @@ mod grammar {
                                 *last_idx = n.end_byte();
                                 return out;
                             } else {
-                                let node: Option<rust_sitter::Node> = None;
+                                let node: Option<rust_sitter::tree_sitter::Node> = None;
                                 return rust_sitter::Extract::extract(node, source, *last_idx);
                             }
                         } else {
                             *last_idx = n.end_byte();
                         }
                         if !cursor.goto_next_sibling() {
-                            let node: Option<rust_sitter::Node> = None;
+                            let node: Option<rust_sitter::tree_sitter::Node> = None;
                             return rust_sitter::Extract::extract(node, source, *last_idx);
                         }
                     }
                 } else {
-                    let node: Option<rust_sitter::Node> = None;
+                    let node: Option<rust_sitter::tree_sitter::Node> = None;
                     return rust_sitter::Extract::extract(node, source, *last_idx);
                 }
             }
             #[allow(non_snake_case)]
             #[allow(clippy::unused_unit)]
             fn extract_Expr_Neg_value(
-                cursor_opt: &mut Option<rust_sitter::TreeCursor>,
+                cursor_opt: &mut Option<rust_sitter::tree_sitter::TreeCursor>,
                 source: &[u8],
                 last_idx: &mut usize,
             ) -> Box<Expr> {
@@ -115,7 +119,7 @@ mod grammar {
                         let n = cursor.node();
                         if let Some(name) = cursor.field_name() {
                             if name == "value" {
-                                let node: Option<rust_sitter::Node> = Some(n);
+                                let node: Option<rust_sitter::tree_sitter::Node> = Some(n);
                                 let out = rust_sitter::Extract::extract(node, source, *last_idx);
                                 if !cursor.goto_next_sibling() {
                                     *cursor_opt = None;
@@ -123,24 +127,24 @@ mod grammar {
                                 *last_idx = n.end_byte();
                                 return out;
                             } else {
-                                let node: Option<rust_sitter::Node> = None;
+                                let node: Option<rust_sitter::tree_sitter::Node> = None;
                                 return rust_sitter::Extract::extract(node, source, *last_idx);
                             }
                         } else {
                             *last_idx = n.end_byte();
                         }
                         if !cursor.goto_next_sibling() {
-                            let node: Option<rust_sitter::Node> = None;
+                            let node: Option<rust_sitter::tree_sitter::Node> = None;
                             return rust_sitter::Extract::extract(node, source, *last_idx);
                         }
                     }
                 } else {
-                    let node: Option<rust_sitter::Node> = None;
+                    let node: Option<rust_sitter::tree_sitter::Node> = None;
                     return rust_sitter::Extract::extract(node, source, *last_idx);
                 }
             }
             #[allow(non_snake_case)]
-            fn extract_Expr_Neg(node: rust_sitter::Node, source: &[u8]) -> Expr {
+            fn extract_Expr_Neg(node: rust_sitter::tree_sitter::Node, source: &[u8]) -> Expr {
                 let mut last_idx = node.start_byte();
                 let mut parent_cursor = node.walk();
                 let mut cursor = if parent_cursor.goto_first_child() {
@@ -161,13 +165,13 @@ mod grammar {
         }
     }
     extern "C" {
-        fn tree_sitter_test() -> rust_sitter::Language;
+        fn tree_sitter_test() -> rust_sitter::tree_sitter::Language;
     }
-    fn language() -> rust_sitter::Language {
+    fn language() -> rust_sitter::tree_sitter::Language {
         unsafe { tree_sitter_test() }
     }
     pub fn parse(input: &str) -> core::result::Result<Expr, Vec<rust_sitter::errors::ParseError>> {
-        let mut parser = rust_sitter::Parser::new();
+        let mut parser = rust_sitter::tree_sitter::Parser::new();
         parser.set_language(language()).unwrap();
         let tree = parser.parse(input, None).unwrap();
         let root_node = tree.root_node();

--- a/macro/src/snapshots/rust_sitter_macro__tests__enum_with_unamed_vector.snap
+++ b/macro/src/snapshots/rust_sitter_macro__tests__enum_with_unamed_vector.snap
@@ -8,12 +8,16 @@ mod grammar {
     }
     impl rust_sitter::Extract for Number {
         #[allow(non_snake_case)]
-        fn extract(node: Option<rust_sitter::Node>, source: &[u8], last_idx: usize) -> Self {
+        fn extract(
+            node: Option<rust_sitter::tree_sitter::Node>,
+            source: &[u8],
+            last_idx: usize,
+        ) -> Self {
             let node = node.unwrap();
             #[allow(non_snake_case)]
             #[allow(clippy::unused_unit)]
             fn extract_Number_value(
-                cursor_opt: &mut Option<rust_sitter::TreeCursor>,
+                cursor_opt: &mut Option<rust_sitter::tree_sitter::TreeCursor>,
                 source: &[u8],
                 last_idx: &mut usize,
             ) -> u32 {
@@ -25,7 +29,7 @@ mod grammar {
                         let n = cursor.node();
                         if let Some(name) = cursor.field_name() {
                             if name == "value" {
-                                let node: Option<rust_sitter::Node> = Some(n);
+                                let node: Option<rust_sitter::tree_sitter::Node> = Some(n);
                                 let out = make_transform()(
                                     node.and_then(|n| n.utf8_text(source).ok()).unwrap(),
                                 );
@@ -35,7 +39,7 @@ mod grammar {
                                 *last_idx = n.end_byte();
                                 return out;
                             } else {
-                                let node: Option<rust_sitter::Node> = None;
+                                let node: Option<rust_sitter::tree_sitter::Node> = None;
                                 return make_transform()(
                                     node.and_then(|n| n.utf8_text(source).ok()).unwrap(),
                                 );
@@ -44,19 +48,19 @@ mod grammar {
                             *last_idx = n.end_byte();
                         }
                         if !cursor.goto_next_sibling() {
-                            let node: Option<rust_sitter::Node> = None;
+                            let node: Option<rust_sitter::tree_sitter::Node> = None;
                             return make_transform()(
                                 node.and_then(|n| n.utf8_text(source).ok()).unwrap(),
                             );
                         }
                     }
                 } else {
-                    let node: Option<rust_sitter::Node> = None;
+                    let node: Option<rust_sitter::tree_sitter::Node> = None;
                     return make_transform()(node.and_then(|n| n.utf8_text(source).ok()).unwrap());
                 }
             }
             #[allow(non_snake_case)]
-            fn extract_Number(node: rust_sitter::Node, source: &[u8]) -> Number {
+            fn extract_Number(node: rust_sitter::tree_sitter::Node, source: &[u8]) -> Number {
                 let mut last_idx = node.start_byte();
                 let mut parent_cursor = node.walk();
                 let mut cursor = if parent_cursor.goto_first_child() {
@@ -76,12 +80,16 @@ mod grammar {
     }
     impl rust_sitter::Extract for Expr {
         #[allow(non_snake_case)]
-        fn extract(node: Option<rust_sitter::Node>, source: &[u8], last_idx: usize) -> Self {
+        fn extract(
+            node: Option<rust_sitter::tree_sitter::Node>,
+            source: &[u8],
+            last_idx: usize,
+        ) -> Self {
             let node = node.unwrap();
             #[allow(non_snake_case)]
             #[allow(clippy::unused_unit)]
             fn extract_Expr_Numbers_0(
-                cursor_opt: &mut Option<rust_sitter::TreeCursor>,
+                cursor_opt: &mut Option<rust_sitter::tree_sitter::TreeCursor>,
                 source: &[u8],
                 last_idx: &mut usize,
             ) -> Vec<Number> {
@@ -90,7 +98,7 @@ mod grammar {
                         let n = cursor.node();
                         if let Some(name) = cursor.field_name() {
                             if name == "0" {
-                                let node: Option<rust_sitter::Node> = Some(n);
+                                let node: Option<rust_sitter::tree_sitter::Node> = Some(n);
                                 let out = rust_sitter::Extract::extract(node, source, *last_idx);
                                 if !cursor.goto_next_sibling() {
                                     *cursor_opt = None;
@@ -98,24 +106,24 @@ mod grammar {
                                 *last_idx = n.end_byte();
                                 return out;
                             } else {
-                                let node: Option<rust_sitter::Node> = None;
+                                let node: Option<rust_sitter::tree_sitter::Node> = None;
                                 return rust_sitter::Extract::extract(node, source, *last_idx);
                             }
                         } else {
                             *last_idx = n.end_byte();
                         }
                         if !cursor.goto_next_sibling() {
-                            let node: Option<rust_sitter::Node> = None;
+                            let node: Option<rust_sitter::tree_sitter::Node> = None;
                             return rust_sitter::Extract::extract(node, source, *last_idx);
                         }
                     }
                 } else {
-                    let node: Option<rust_sitter::Node> = None;
+                    let node: Option<rust_sitter::tree_sitter::Node> = None;
                     return rust_sitter::Extract::extract(node, source, *last_idx);
                 }
             }
             #[allow(non_snake_case)]
-            fn extract_Expr_Numbers(node: rust_sitter::Node, source: &[u8]) -> Expr {
+            fn extract_Expr_Numbers(node: rust_sitter::tree_sitter::Node, source: &[u8]) -> Expr {
                 let mut last_idx = node.start_byte();
                 let mut parent_cursor = node.walk();
                 let mut cursor = if parent_cursor.goto_first_child() {
@@ -132,13 +140,13 @@ mod grammar {
         }
     }
     extern "C" {
-        fn tree_sitter_test() -> rust_sitter::Language;
+        fn tree_sitter_test() -> rust_sitter::tree_sitter::Language;
     }
-    fn language() -> rust_sitter::Language {
+    fn language() -> rust_sitter::tree_sitter::Language {
         unsafe { tree_sitter_test() }
     }
     pub fn parse(input: &str) -> core::result::Result<Expr, Vec<rust_sitter::errors::ParseError>> {
-        let mut parser = rust_sitter::Parser::new();
+        let mut parser = rust_sitter::tree_sitter::Parser::new();
         parser.set_language(language()).unwrap();
         let tree = parser.parse(input, None).unwrap();
         let root_node = tree.root_node();

--- a/macro/src/snapshots/rust_sitter_macro__tests__grammar_unboxed_field.snap
+++ b/macro/src/snapshots/rust_sitter_macro__tests__grammar_unboxed_field.snap
@@ -8,12 +8,16 @@ mod grammar {
     }
     impl rust_sitter::Extract for Language {
         #[allow(non_snake_case)]
-        fn extract(node: Option<rust_sitter::Node>, source: &[u8], last_idx: usize) -> Self {
+        fn extract(
+            node: Option<rust_sitter::tree_sitter::Node>,
+            source: &[u8],
+            last_idx: usize,
+        ) -> Self {
             let node = node.unwrap();
             #[allow(non_snake_case)]
             #[allow(clippy::unused_unit)]
             fn extract_Language_e(
-                cursor_opt: &mut Option<rust_sitter::TreeCursor>,
+                cursor_opt: &mut Option<rust_sitter::tree_sitter::TreeCursor>,
                 source: &[u8],
                 last_idx: &mut usize,
             ) -> Expression {
@@ -22,7 +26,7 @@ mod grammar {
                         let n = cursor.node();
                         if let Some(name) = cursor.field_name() {
                             if name == "e" {
-                                let node: Option<rust_sitter::Node> = Some(n);
+                                let node: Option<rust_sitter::tree_sitter::Node> = Some(n);
                                 let out = rust_sitter::Extract::extract(node, source, *last_idx);
                                 if !cursor.goto_next_sibling() {
                                     *cursor_opt = None;
@@ -30,24 +34,24 @@ mod grammar {
                                 *last_idx = n.end_byte();
                                 return out;
                             } else {
-                                let node: Option<rust_sitter::Node> = None;
+                                let node: Option<rust_sitter::tree_sitter::Node> = None;
                                 return rust_sitter::Extract::extract(node, source, *last_idx);
                             }
                         } else {
                             *last_idx = n.end_byte();
                         }
                         if !cursor.goto_next_sibling() {
-                            let node: Option<rust_sitter::Node> = None;
+                            let node: Option<rust_sitter::tree_sitter::Node> = None;
                             return rust_sitter::Extract::extract(node, source, *last_idx);
                         }
                     }
                 } else {
-                    let node: Option<rust_sitter::Node> = None;
+                    let node: Option<rust_sitter::tree_sitter::Node> = None;
                     return rust_sitter::Extract::extract(node, source, *last_idx);
                 }
             }
             #[allow(non_snake_case)]
-            fn extract_Language(node: rust_sitter::Node, source: &[u8]) -> Language {
+            fn extract_Language(node: rust_sitter::tree_sitter::Node, source: &[u8]) -> Language {
                 let mut last_idx = node.start_byte();
                 let mut parent_cursor = node.walk();
                 let mut cursor = if parent_cursor.goto_first_child() {
@@ -67,12 +71,16 @@ mod grammar {
     }
     impl rust_sitter::Extract for Expression {
         #[allow(non_snake_case)]
-        fn extract(node: Option<rust_sitter::Node>, source: &[u8], last_idx: usize) -> Self {
+        fn extract(
+            node: Option<rust_sitter::tree_sitter::Node>,
+            source: &[u8],
+            last_idx: usize,
+        ) -> Self {
             let node = node.unwrap();
             #[allow(non_snake_case)]
             #[allow(clippy::unused_unit)]
             fn extract_Expression_Number_0(
-                cursor_opt: &mut Option<rust_sitter::TreeCursor>,
+                cursor_opt: &mut Option<rust_sitter::tree_sitter::TreeCursor>,
                 source: &[u8],
                 last_idx: &mut usize,
             ) -> i32 {
@@ -84,7 +92,7 @@ mod grammar {
                         let n = cursor.node();
                         if let Some(name) = cursor.field_name() {
                             if name == "0" {
-                                let node: Option<rust_sitter::Node> = Some(n);
+                                let node: Option<rust_sitter::tree_sitter::Node> = Some(n);
                                 let out = make_transform()(
                                     node.and_then(|n| n.utf8_text(source).ok()).unwrap(),
                                 );
@@ -94,7 +102,7 @@ mod grammar {
                                 *last_idx = n.end_byte();
                                 return out;
                             } else {
-                                let node: Option<rust_sitter::Node> = None;
+                                let node: Option<rust_sitter::tree_sitter::Node> = None;
                                 return make_transform()(
                                     node.and_then(|n| n.utf8_text(source).ok()).unwrap(),
                                 );
@@ -103,19 +111,22 @@ mod grammar {
                             *last_idx = n.end_byte();
                         }
                         if !cursor.goto_next_sibling() {
-                            let node: Option<rust_sitter::Node> = None;
+                            let node: Option<rust_sitter::tree_sitter::Node> = None;
                             return make_transform()(
                                 node.and_then(|n| n.utf8_text(source).ok()).unwrap(),
                             );
                         }
                     }
                 } else {
-                    let node: Option<rust_sitter::Node> = None;
+                    let node: Option<rust_sitter::tree_sitter::Node> = None;
                     return make_transform()(node.and_then(|n| n.utf8_text(source).ok()).unwrap());
                 }
             }
             #[allow(non_snake_case)]
-            fn extract_Expression_Number(node: rust_sitter::Node, source: &[u8]) -> Expression {
+            fn extract_Expression_Number(
+                node: rust_sitter::tree_sitter::Node,
+                source: &[u8],
+            ) -> Expression {
                 let mut last_idx = node.start_byte();
                 let mut parent_cursor = node.walk();
                 let mut cursor = if parent_cursor.goto_first_child() {
@@ -136,15 +147,15 @@ mod grammar {
         }
     }
     extern "C" {
-        fn tree_sitter_test() -> rust_sitter::Language;
+        fn tree_sitter_test() -> rust_sitter::tree_sitter::Language;
     }
-    fn language() -> rust_sitter::Language {
+    fn language() -> rust_sitter::tree_sitter::Language {
         unsafe { tree_sitter_test() }
     }
     pub fn parse(
         input: &str,
     ) -> core::result::Result<Language, Vec<rust_sitter::errors::ParseError>> {
-        let mut parser = rust_sitter::Parser::new();
+        let mut parser = rust_sitter::tree_sitter::Parser::new();
         parser.set_language(language()).unwrap();
         let tree = parser.parse(input, None).unwrap();
         let root_node = tree.root_node();

--- a/macro/src/snapshots/rust_sitter_macro__tests__spanned_in_vec.snap
+++ b/macro/src/snapshots/rust_sitter_macro__tests__spanned_in_vec.snap
@@ -9,12 +9,16 @@ mod grammar {
     }
     impl rust_sitter::Extract for NumberList {
         #[allow(non_snake_case)]
-        fn extract(node: Option<rust_sitter::Node>, source: &[u8], last_idx: usize) -> Self {
+        fn extract(
+            node: Option<rust_sitter::tree_sitter::Node>,
+            source: &[u8],
+            last_idx: usize,
+        ) -> Self {
             let node = node.unwrap();
             #[allow(non_snake_case)]
             #[allow(clippy::unused_unit)]
             fn extract_NumberList_numbers(
-                cursor_opt: &mut Option<rust_sitter::TreeCursor>,
+                cursor_opt: &mut Option<rust_sitter::tree_sitter::TreeCursor>,
                 source: &[u8],
                 last_idx: &mut usize,
             ) -> Vec<Spanned<Number>> {
@@ -23,7 +27,7 @@ mod grammar {
                         let n = cursor.node();
                         if let Some(name) = cursor.field_name() {
                             if name == "numbers" {
-                                let node: Option<rust_sitter::Node> = Some(n);
+                                let node: Option<rust_sitter::tree_sitter::Node> = Some(n);
                                 let out = rust_sitter::Extract::extract(node, source, *last_idx);
                                 if !cursor.goto_next_sibling() {
                                     *cursor_opt = None;
@@ -31,24 +35,27 @@ mod grammar {
                                 *last_idx = n.end_byte();
                                 return out;
                             } else {
-                                let node: Option<rust_sitter::Node> = None;
+                                let node: Option<rust_sitter::tree_sitter::Node> = None;
                                 return rust_sitter::Extract::extract(node, source, *last_idx);
                             }
                         } else {
                             *last_idx = n.end_byte();
                         }
                         if !cursor.goto_next_sibling() {
-                            let node: Option<rust_sitter::Node> = None;
+                            let node: Option<rust_sitter::tree_sitter::Node> = None;
                             return rust_sitter::Extract::extract(node, source, *last_idx);
                         }
                     }
                 } else {
-                    let node: Option<rust_sitter::Node> = None;
+                    let node: Option<rust_sitter::tree_sitter::Node> = None;
                     return rust_sitter::Extract::extract(node, source, *last_idx);
                 }
             }
             #[allow(non_snake_case)]
-            fn extract_NumberList(node: rust_sitter::Node, source: &[u8]) -> NumberList {
+            fn extract_NumberList(
+                node: rust_sitter::tree_sitter::Node,
+                source: &[u8],
+            ) -> NumberList {
                 let mut last_idx = node.start_byte();
                 let mut parent_cursor = node.walk();
                 let mut cursor = if parent_cursor.goto_first_child() {
@@ -68,12 +75,16 @@ mod grammar {
     }
     impl rust_sitter::Extract for Number {
         #[allow(non_snake_case)]
-        fn extract(node: Option<rust_sitter::Node>, source: &[u8], last_idx: usize) -> Self {
+        fn extract(
+            node: Option<rust_sitter::tree_sitter::Node>,
+            source: &[u8],
+            last_idx: usize,
+        ) -> Self {
             let node = node.unwrap();
             #[allow(non_snake_case)]
             #[allow(clippy::unused_unit)]
             fn extract_Number_v(
-                cursor_opt: &mut Option<rust_sitter::TreeCursor>,
+                cursor_opt: &mut Option<rust_sitter::tree_sitter::TreeCursor>,
                 source: &[u8],
                 last_idx: &mut usize,
             ) -> i32 {
@@ -85,7 +96,7 @@ mod grammar {
                         let n = cursor.node();
                         if let Some(name) = cursor.field_name() {
                             if name == "v" {
-                                let node: Option<rust_sitter::Node> = Some(n);
+                                let node: Option<rust_sitter::tree_sitter::Node> = Some(n);
                                 let out = make_transform()(
                                     node.and_then(|n| n.utf8_text(source).ok()).unwrap(),
                                 );
@@ -95,7 +106,7 @@ mod grammar {
                                 *last_idx = n.end_byte();
                                 return out;
                             } else {
-                                let node: Option<rust_sitter::Node> = None;
+                                let node: Option<rust_sitter::tree_sitter::Node> = None;
                                 return make_transform()(
                                     node.and_then(|n| n.utf8_text(source).ok()).unwrap(),
                                 );
@@ -104,19 +115,19 @@ mod grammar {
                             *last_idx = n.end_byte();
                         }
                         if !cursor.goto_next_sibling() {
-                            let node: Option<rust_sitter::Node> = None;
+                            let node: Option<rust_sitter::tree_sitter::Node> = None;
                             return make_transform()(
                                 node.and_then(|n| n.utf8_text(source).ok()).unwrap(),
                             );
                         }
                     }
                 } else {
-                    let node: Option<rust_sitter::Node> = None;
+                    let node: Option<rust_sitter::tree_sitter::Node> = None;
                     return make_transform()(node.and_then(|n| n.utf8_text(source).ok()).unwrap());
                 }
             }
             #[allow(non_snake_case)]
-            fn extract_Number(node: rust_sitter::Node, source: &[u8]) -> Number {
+            fn extract_Number(node: rust_sitter::tree_sitter::Node, source: &[u8]) -> Number {
                 let mut last_idx = node.start_byte();
                 let mut parent_cursor = node.walk();
                 let mut cursor = if parent_cursor.goto_first_child() {
@@ -136,12 +147,16 @@ mod grammar {
     }
     impl rust_sitter::Extract for Whitespace {
         #[allow(non_snake_case)]
-        fn extract(node: Option<rust_sitter::Node>, source: &[u8], last_idx: usize) -> Self {
+        fn extract(
+            node: Option<rust_sitter::tree_sitter::Node>,
+            source: &[u8],
+            last_idx: usize,
+        ) -> Self {
             let node = node.unwrap();
             #[allow(non_snake_case)]
             #[allow(clippy::unused_unit)]
             fn extract_Whitespace__whitespace(
-                cursor_opt: &mut Option<rust_sitter::TreeCursor>,
+                cursor_opt: &mut Option<rust_sitter::tree_sitter::TreeCursor>,
                 source: &[u8],
                 last_idx: &mut usize,
             ) -> () {
@@ -150,7 +165,7 @@ mod grammar {
                         let n = cursor.node();
                         if let Some(name) = cursor.field_name() {
                             if name == "_whitespace" {
-                                let node: Option<rust_sitter::Node> = Some(n);
+                                let node: Option<rust_sitter::tree_sitter::Node> = Some(n);
                                 let out = rust_sitter::Extract::extract(node, source, *last_idx);
                                 if !cursor.goto_next_sibling() {
                                     *cursor_opt = None;
@@ -158,24 +173,27 @@ mod grammar {
                                 *last_idx = n.end_byte();
                                 return out;
                             } else {
-                                let node: Option<rust_sitter::Node> = None;
+                                let node: Option<rust_sitter::tree_sitter::Node> = None;
                                 return rust_sitter::Extract::extract(node, source, *last_idx);
                             }
                         } else {
                             *last_idx = n.end_byte();
                         }
                         if !cursor.goto_next_sibling() {
-                            let node: Option<rust_sitter::Node> = None;
+                            let node: Option<rust_sitter::tree_sitter::Node> = None;
                             return rust_sitter::Extract::extract(node, source, *last_idx);
                         }
                     }
                 } else {
-                    let node: Option<rust_sitter::Node> = None;
+                    let node: Option<rust_sitter::tree_sitter::Node> = None;
                     return rust_sitter::Extract::extract(node, source, *last_idx);
                 }
             }
             #[allow(non_snake_case)]
-            fn extract_Whitespace(node: rust_sitter::Node, source: &[u8]) -> Whitespace {
+            fn extract_Whitespace(
+                node: rust_sitter::tree_sitter::Node,
+                source: &[u8],
+            ) -> Whitespace {
                 let mut last_idx = node.start_byte();
                 let mut parent_cursor = node.walk();
                 let mut cursor = if parent_cursor.goto_first_child() {
@@ -191,15 +209,15 @@ mod grammar {
         }
     }
     extern "C" {
-        fn tree_sitter_test() -> rust_sitter::Language;
+        fn tree_sitter_test() -> rust_sitter::tree_sitter::Language;
     }
-    fn language() -> rust_sitter::Language {
+    fn language() -> rust_sitter::tree_sitter::Language {
         unsafe { tree_sitter_test() }
     }
     pub fn parse(
         input: &str,
     ) -> core::result::Result<NumberList, Vec<rust_sitter::errors::ParseError>> {
-        let mut parser = rust_sitter::Parser::new();
+        let mut parser = rust_sitter::tree_sitter::Parser::new();
         parser.set_language(language()).unwrap();
         let tree = parser.parse(input, None).unwrap();
         let root_node = tree.root_node();

--- a/macro/src/snapshots/rust_sitter_macro__tests__struct_extra.snap
+++ b/macro/src/snapshots/rust_sitter_macro__tests__struct_extra.snap
@@ -8,12 +8,16 @@ mod grammar {
     }
     impl rust_sitter::Extract for Expression {
         #[allow(non_snake_case)]
-        fn extract(node: Option<rust_sitter::Node>, source: &[u8], last_idx: usize) -> Self {
+        fn extract(
+            node: Option<rust_sitter::tree_sitter::Node>,
+            source: &[u8],
+            last_idx: usize,
+        ) -> Self {
             let node = node.unwrap();
             #[allow(non_snake_case)]
             #[allow(clippy::unused_unit)]
             fn extract_Expression_Number_0(
-                cursor_opt: &mut Option<rust_sitter::TreeCursor>,
+                cursor_opt: &mut Option<rust_sitter::tree_sitter::TreeCursor>,
                 source: &[u8],
                 last_idx: &mut usize,
             ) -> i32 {
@@ -25,7 +29,7 @@ mod grammar {
                         let n = cursor.node();
                         if let Some(name) = cursor.field_name() {
                             if name == "0" {
-                                let node: Option<rust_sitter::Node> = Some(n);
+                                let node: Option<rust_sitter::tree_sitter::Node> = Some(n);
                                 let out = make_transform()(
                                     node.and_then(|n| n.utf8_text(source).ok()).unwrap(),
                                 );
@@ -35,7 +39,7 @@ mod grammar {
                                 *last_idx = n.end_byte();
                                 return out;
                             } else {
-                                let node: Option<rust_sitter::Node> = None;
+                                let node: Option<rust_sitter::tree_sitter::Node> = None;
                                 return make_transform()(
                                     node.and_then(|n| n.utf8_text(source).ok()).unwrap(),
                                 );
@@ -44,19 +48,22 @@ mod grammar {
                             *last_idx = n.end_byte();
                         }
                         if !cursor.goto_next_sibling() {
-                            let node: Option<rust_sitter::Node> = None;
+                            let node: Option<rust_sitter::tree_sitter::Node> = None;
                             return make_transform()(
                                 node.and_then(|n| n.utf8_text(source).ok()).unwrap(),
                             );
                         }
                     }
                 } else {
-                    let node: Option<rust_sitter::Node> = None;
+                    let node: Option<rust_sitter::tree_sitter::Node> = None;
                     return make_transform()(node.and_then(|n| n.utf8_text(source).ok()).unwrap());
                 }
             }
             #[allow(non_snake_case)]
-            fn extract_Expression_Number(node: rust_sitter::Node, source: &[u8]) -> Expression {
+            fn extract_Expression_Number(
+                node: rust_sitter::tree_sitter::Node,
+                source: &[u8],
+            ) -> Expression {
                 let mut last_idx = node.start_byte();
                 let mut parent_cursor = node.walk();
                 let mut cursor = if parent_cursor.goto_first_child() {
@@ -81,12 +88,16 @@ mod grammar {
     }
     impl rust_sitter::Extract for Whitespace {
         #[allow(non_snake_case)]
-        fn extract(node: Option<rust_sitter::Node>, source: &[u8], last_idx: usize) -> Self {
+        fn extract(
+            node: Option<rust_sitter::tree_sitter::Node>,
+            source: &[u8],
+            last_idx: usize,
+        ) -> Self {
             let node = node.unwrap();
             #[allow(non_snake_case)]
             #[allow(clippy::unused_unit)]
             fn extract_Whitespace__whitespace(
-                cursor_opt: &mut Option<rust_sitter::TreeCursor>,
+                cursor_opt: &mut Option<rust_sitter::tree_sitter::TreeCursor>,
                 source: &[u8],
                 last_idx: &mut usize,
             ) -> () {
@@ -95,7 +106,7 @@ mod grammar {
                         let n = cursor.node();
                         if let Some(name) = cursor.field_name() {
                             if name == "_whitespace" {
-                                let node: Option<rust_sitter::Node> = Some(n);
+                                let node: Option<rust_sitter::tree_sitter::Node> = Some(n);
                                 let out = rust_sitter::Extract::extract(node, source, *last_idx);
                                 if !cursor.goto_next_sibling() {
                                     *cursor_opt = None;
@@ -103,24 +114,27 @@ mod grammar {
                                 *last_idx = n.end_byte();
                                 return out;
                             } else {
-                                let node: Option<rust_sitter::Node> = None;
+                                let node: Option<rust_sitter::tree_sitter::Node> = None;
                                 return rust_sitter::Extract::extract(node, source, *last_idx);
                             }
                         } else {
                             *last_idx = n.end_byte();
                         }
                         if !cursor.goto_next_sibling() {
-                            let node: Option<rust_sitter::Node> = None;
+                            let node: Option<rust_sitter::tree_sitter::Node> = None;
                             return rust_sitter::Extract::extract(node, source, *last_idx);
                         }
                     }
                 } else {
-                    let node: Option<rust_sitter::Node> = None;
+                    let node: Option<rust_sitter::tree_sitter::Node> = None;
                     return rust_sitter::Extract::extract(node, source, *last_idx);
                 }
             }
             #[allow(non_snake_case)]
-            fn extract_Whitespace(node: rust_sitter::Node, source: &[u8]) -> Whitespace {
+            fn extract_Whitespace(
+                node: rust_sitter::tree_sitter::Node,
+                source: &[u8],
+            ) -> Whitespace {
                 let mut last_idx = node.start_byte();
                 let mut parent_cursor = node.walk();
                 let mut cursor = if parent_cursor.goto_first_child() {
@@ -136,15 +150,15 @@ mod grammar {
         }
     }
     extern "C" {
-        fn tree_sitter_test() -> rust_sitter::Language;
+        fn tree_sitter_test() -> rust_sitter::tree_sitter::Language;
     }
-    fn language() -> rust_sitter::Language {
+    fn language() -> rust_sitter::tree_sitter::Language {
         unsafe { tree_sitter_test() }
     }
     pub fn parse(
         input: &str,
     ) -> core::result::Result<Expression, Vec<rust_sitter::errors::ParseError>> {
-        let mut parser = rust_sitter::Parser::new();
+        let mut parser = rust_sitter::tree_sitter::Parser::new();
         parser.set_language(language()).unwrap();
         let tree = parser.parse(input, None).unwrap();
         let root_node = tree.root_node();

--- a/macro/src/snapshots/rust_sitter_macro__tests__struct_optional.snap
+++ b/macro/src/snapshots/rust_sitter_macro__tests__struct_optional.snap
@@ -9,12 +9,16 @@ mod grammar {
     }
     impl rust_sitter::Extract for Language {
         #[allow(non_snake_case)]
-        fn extract(node: Option<rust_sitter::Node>, source: &[u8], last_idx: usize) -> Self {
+        fn extract(
+            node: Option<rust_sitter::tree_sitter::Node>,
+            source: &[u8],
+            last_idx: usize,
+        ) -> Self {
             let node = node.unwrap();
             #[allow(non_snake_case)]
             #[allow(clippy::unused_unit)]
             fn extract_Language_v(
-                cursor_opt: &mut Option<rust_sitter::TreeCursor>,
+                cursor_opt: &mut Option<rust_sitter::tree_sitter::TreeCursor>,
                 source: &[u8],
                 last_idx: &mut usize,
             ) -> Option<i32> {
@@ -26,7 +30,7 @@ mod grammar {
                         let n = cursor.node();
                         if let Some(name) = cursor.field_name() {
                             if name == "v" {
-                                let node: Option<rust_sitter::Node> = Some(n);
+                                let node: Option<rust_sitter::tree_sitter::Node> = Some(n);
                                 let out = node
                                     .and_then(|n| n.utf8_text(source).ok())
                                     .map(|t| make_transform()(t));
@@ -36,7 +40,7 @@ mod grammar {
                                 *last_idx = n.end_byte();
                                 return out;
                             } else {
-                                let node: Option<rust_sitter::Node> = None;
+                                let node: Option<rust_sitter::tree_sitter::Node> = None;
                                 return node
                                     .and_then(|n| n.utf8_text(source).ok())
                                     .map(|t| make_transform()(t));
@@ -45,14 +49,14 @@ mod grammar {
                             *last_idx = n.end_byte();
                         }
                         if !cursor.goto_next_sibling() {
-                            let node: Option<rust_sitter::Node> = None;
+                            let node: Option<rust_sitter::tree_sitter::Node> = None;
                             return node
                                 .and_then(|n| n.utf8_text(source).ok())
                                 .map(|t| make_transform()(t));
                         }
                     }
                 } else {
-                    let node: Option<rust_sitter::Node> = None;
+                    let node: Option<rust_sitter::tree_sitter::Node> = None;
                     return node
                         .and_then(|n| n.utf8_text(source).ok())
                         .map(|t| make_transform()(t));
@@ -61,7 +65,7 @@ mod grammar {
             #[allow(non_snake_case)]
             #[allow(clippy::unused_unit)]
             fn extract_Language_t(
-                cursor_opt: &mut Option<rust_sitter::TreeCursor>,
+                cursor_opt: &mut Option<rust_sitter::tree_sitter::TreeCursor>,
                 source: &[u8],
                 last_idx: &mut usize,
             ) -> Option<Number> {
@@ -70,7 +74,7 @@ mod grammar {
                         let n = cursor.node();
                         if let Some(name) = cursor.field_name() {
                             if name == "t" {
-                                let node: Option<rust_sitter::Node> = Some(n);
+                                let node: Option<rust_sitter::tree_sitter::Node> = Some(n);
                                 let out = rust_sitter::Extract::extract(node, source, *last_idx);
                                 if !cursor.goto_next_sibling() {
                                     *cursor_opt = None;
@@ -78,24 +82,24 @@ mod grammar {
                                 *last_idx = n.end_byte();
                                 return out;
                             } else {
-                                let node: Option<rust_sitter::Node> = None;
+                                let node: Option<rust_sitter::tree_sitter::Node> = None;
                                 return rust_sitter::Extract::extract(node, source, *last_idx);
                             }
                         } else {
                             *last_idx = n.end_byte();
                         }
                         if !cursor.goto_next_sibling() {
-                            let node: Option<rust_sitter::Node> = None;
+                            let node: Option<rust_sitter::tree_sitter::Node> = None;
                             return rust_sitter::Extract::extract(node, source, *last_idx);
                         }
                     }
                 } else {
-                    let node: Option<rust_sitter::Node> = None;
+                    let node: Option<rust_sitter::tree_sitter::Node> = None;
                     return rust_sitter::Extract::extract(node, source, *last_idx);
                 }
             }
             #[allow(non_snake_case)]
-            fn extract_Language(node: rust_sitter::Node, source: &[u8]) -> Language {
+            fn extract_Language(node: rust_sitter::tree_sitter::Node, source: &[u8]) -> Language {
                 let mut last_idx = node.start_byte();
                 let mut parent_cursor = node.walk();
                 let mut cursor = if parent_cursor.goto_first_child() {
@@ -116,12 +120,16 @@ mod grammar {
     }
     impl rust_sitter::Extract for Number {
         #[allow(non_snake_case)]
-        fn extract(node: Option<rust_sitter::Node>, source: &[u8], last_idx: usize) -> Self {
+        fn extract(
+            node: Option<rust_sitter::tree_sitter::Node>,
+            source: &[u8],
+            last_idx: usize,
+        ) -> Self {
             let node = node.unwrap();
             #[allow(non_snake_case)]
             #[allow(clippy::unused_unit)]
             fn extract_Number_v(
-                cursor_opt: &mut Option<rust_sitter::TreeCursor>,
+                cursor_opt: &mut Option<rust_sitter::tree_sitter::TreeCursor>,
                 source: &[u8],
                 last_idx: &mut usize,
             ) -> i32 {
@@ -133,7 +141,7 @@ mod grammar {
                         let n = cursor.node();
                         if let Some(name) = cursor.field_name() {
                             if name == "v" {
-                                let node: Option<rust_sitter::Node> = Some(n);
+                                let node: Option<rust_sitter::tree_sitter::Node> = Some(n);
                                 let out = make_transform()(
                                     node.and_then(|n| n.utf8_text(source).ok()).unwrap(),
                                 );
@@ -143,7 +151,7 @@ mod grammar {
                                 *last_idx = n.end_byte();
                                 return out;
                             } else {
-                                let node: Option<rust_sitter::Node> = None;
+                                let node: Option<rust_sitter::tree_sitter::Node> = None;
                                 return make_transform()(
                                     node.and_then(|n| n.utf8_text(source).ok()).unwrap(),
                                 );
@@ -152,19 +160,19 @@ mod grammar {
                             *last_idx = n.end_byte();
                         }
                         if !cursor.goto_next_sibling() {
-                            let node: Option<rust_sitter::Node> = None;
+                            let node: Option<rust_sitter::tree_sitter::Node> = None;
                             return make_transform()(
                                 node.and_then(|n| n.utf8_text(source).ok()).unwrap(),
                             );
                         }
                     }
                 } else {
-                    let node: Option<rust_sitter::Node> = None;
+                    let node: Option<rust_sitter::tree_sitter::Node> = None;
                     return make_transform()(node.and_then(|n| n.utf8_text(source).ok()).unwrap());
                 }
             }
             #[allow(non_snake_case)]
-            fn extract_Number(node: rust_sitter::Node, source: &[u8]) -> Number {
+            fn extract_Number(node: rust_sitter::tree_sitter::Node, source: &[u8]) -> Number {
                 let mut last_idx = node.start_byte();
                 let mut parent_cursor = node.walk();
                 let mut cursor = if parent_cursor.goto_first_child() {
@@ -180,15 +188,15 @@ mod grammar {
         }
     }
     extern "C" {
-        fn tree_sitter_test() -> rust_sitter::Language;
+        fn tree_sitter_test() -> rust_sitter::tree_sitter::Language;
     }
-    fn language() -> rust_sitter::Language {
+    fn language() -> rust_sitter::tree_sitter::Language {
         unsafe { tree_sitter_test() }
     }
     pub fn parse(
         input: &str,
     ) -> core::result::Result<Language, Vec<rust_sitter::errors::ParseError>> {
-        let mut parser = rust_sitter::Parser::new();
+        let mut parser = rust_sitter::tree_sitter::Parser::new();
         parser.set_language(language()).unwrap();
         let tree = parser.parse(input, None).unwrap();
         let root_node = tree.root_node();

--- a/macro/src/snapshots/rust_sitter_macro__tests__struct_repeat.snap
+++ b/macro/src/snapshots/rust_sitter_macro__tests__struct_repeat.snap
@@ -8,12 +8,16 @@ mod grammar {
     }
     impl rust_sitter::Extract for NumberList {
         #[allow(non_snake_case)]
-        fn extract(node: Option<rust_sitter::Node>, source: &[u8], last_idx: usize) -> Self {
+        fn extract(
+            node: Option<rust_sitter::tree_sitter::Node>,
+            source: &[u8],
+            last_idx: usize,
+        ) -> Self {
             let node = node.unwrap();
             #[allow(non_snake_case)]
             #[allow(clippy::unused_unit)]
             fn extract_NumberList_numbers(
-                cursor_opt: &mut Option<rust_sitter::TreeCursor>,
+                cursor_opt: &mut Option<rust_sitter::tree_sitter::TreeCursor>,
                 source: &[u8],
                 last_idx: &mut usize,
             ) -> Vec<Number> {
@@ -22,7 +26,7 @@ mod grammar {
                         let n = cursor.node();
                         if let Some(name) = cursor.field_name() {
                             if name == "numbers" {
-                                let node: Option<rust_sitter::Node> = Some(n);
+                                let node: Option<rust_sitter::tree_sitter::Node> = Some(n);
                                 let out = rust_sitter::Extract::extract(node, source, *last_idx);
                                 if !cursor.goto_next_sibling() {
                                     *cursor_opt = None;
@@ -30,24 +34,27 @@ mod grammar {
                                 *last_idx = n.end_byte();
                                 return out;
                             } else {
-                                let node: Option<rust_sitter::Node> = None;
+                                let node: Option<rust_sitter::tree_sitter::Node> = None;
                                 return rust_sitter::Extract::extract(node, source, *last_idx);
                             }
                         } else {
                             *last_idx = n.end_byte();
                         }
                         if !cursor.goto_next_sibling() {
-                            let node: Option<rust_sitter::Node> = None;
+                            let node: Option<rust_sitter::tree_sitter::Node> = None;
                             return rust_sitter::Extract::extract(node, source, *last_idx);
                         }
                     }
                 } else {
-                    let node: Option<rust_sitter::Node> = None;
+                    let node: Option<rust_sitter::tree_sitter::Node> = None;
                     return rust_sitter::Extract::extract(node, source, *last_idx);
                 }
             }
             #[allow(non_snake_case)]
-            fn extract_NumberList(node: rust_sitter::Node, source: &[u8]) -> NumberList {
+            fn extract_NumberList(
+                node: rust_sitter::tree_sitter::Node,
+                source: &[u8],
+            ) -> NumberList {
                 let mut last_idx = node.start_byte();
                 let mut parent_cursor = node.walk();
                 let mut cursor = if parent_cursor.goto_first_child() {
@@ -67,12 +74,16 @@ mod grammar {
     }
     impl rust_sitter::Extract for Number {
         #[allow(non_snake_case)]
-        fn extract(node: Option<rust_sitter::Node>, source: &[u8], last_idx: usize) -> Self {
+        fn extract(
+            node: Option<rust_sitter::tree_sitter::Node>,
+            source: &[u8],
+            last_idx: usize,
+        ) -> Self {
             let node = node.unwrap();
             #[allow(non_snake_case)]
             #[allow(clippy::unused_unit)]
             fn extract_Number_v(
-                cursor_opt: &mut Option<rust_sitter::TreeCursor>,
+                cursor_opt: &mut Option<rust_sitter::tree_sitter::TreeCursor>,
                 source: &[u8],
                 last_idx: &mut usize,
             ) -> i32 {
@@ -84,7 +95,7 @@ mod grammar {
                         let n = cursor.node();
                         if let Some(name) = cursor.field_name() {
                             if name == "v" {
-                                let node: Option<rust_sitter::Node> = Some(n);
+                                let node: Option<rust_sitter::tree_sitter::Node> = Some(n);
                                 let out = make_transform()(
                                     node.and_then(|n| n.utf8_text(source).ok()).unwrap(),
                                 );
@@ -94,7 +105,7 @@ mod grammar {
                                 *last_idx = n.end_byte();
                                 return out;
                             } else {
-                                let node: Option<rust_sitter::Node> = None;
+                                let node: Option<rust_sitter::tree_sitter::Node> = None;
                                 return make_transform()(
                                     node.and_then(|n| n.utf8_text(source).ok()).unwrap(),
                                 );
@@ -103,19 +114,19 @@ mod grammar {
                             *last_idx = n.end_byte();
                         }
                         if !cursor.goto_next_sibling() {
-                            let node: Option<rust_sitter::Node> = None;
+                            let node: Option<rust_sitter::tree_sitter::Node> = None;
                             return make_transform()(
                                 node.and_then(|n| n.utf8_text(source).ok()).unwrap(),
                             );
                         }
                     }
                 } else {
-                    let node: Option<rust_sitter::Node> = None;
+                    let node: Option<rust_sitter::tree_sitter::Node> = None;
                     return make_transform()(node.and_then(|n| n.utf8_text(source).ok()).unwrap());
                 }
             }
             #[allow(non_snake_case)]
-            fn extract_Number(node: rust_sitter::Node, source: &[u8]) -> Number {
+            fn extract_Number(node: rust_sitter::tree_sitter::Node, source: &[u8]) -> Number {
                 let mut last_idx = node.start_byte();
                 let mut parent_cursor = node.walk();
                 let mut cursor = if parent_cursor.goto_first_child() {
@@ -135,12 +146,16 @@ mod grammar {
     }
     impl rust_sitter::Extract for Whitespace {
         #[allow(non_snake_case)]
-        fn extract(node: Option<rust_sitter::Node>, source: &[u8], last_idx: usize) -> Self {
+        fn extract(
+            node: Option<rust_sitter::tree_sitter::Node>,
+            source: &[u8],
+            last_idx: usize,
+        ) -> Self {
             let node = node.unwrap();
             #[allow(non_snake_case)]
             #[allow(clippy::unused_unit)]
             fn extract_Whitespace__whitespace(
-                cursor_opt: &mut Option<rust_sitter::TreeCursor>,
+                cursor_opt: &mut Option<rust_sitter::tree_sitter::TreeCursor>,
                 source: &[u8],
                 last_idx: &mut usize,
             ) -> () {
@@ -149,7 +164,7 @@ mod grammar {
                         let n = cursor.node();
                         if let Some(name) = cursor.field_name() {
                             if name == "_whitespace" {
-                                let node: Option<rust_sitter::Node> = Some(n);
+                                let node: Option<rust_sitter::tree_sitter::Node> = Some(n);
                                 let out = rust_sitter::Extract::extract(node, source, *last_idx);
                                 if !cursor.goto_next_sibling() {
                                     *cursor_opt = None;
@@ -157,24 +172,27 @@ mod grammar {
                                 *last_idx = n.end_byte();
                                 return out;
                             } else {
-                                let node: Option<rust_sitter::Node> = None;
+                                let node: Option<rust_sitter::tree_sitter::Node> = None;
                                 return rust_sitter::Extract::extract(node, source, *last_idx);
                             }
                         } else {
                             *last_idx = n.end_byte();
                         }
                         if !cursor.goto_next_sibling() {
-                            let node: Option<rust_sitter::Node> = None;
+                            let node: Option<rust_sitter::tree_sitter::Node> = None;
                             return rust_sitter::Extract::extract(node, source, *last_idx);
                         }
                     }
                 } else {
-                    let node: Option<rust_sitter::Node> = None;
+                    let node: Option<rust_sitter::tree_sitter::Node> = None;
                     return rust_sitter::Extract::extract(node, source, *last_idx);
                 }
             }
             #[allow(non_snake_case)]
-            fn extract_Whitespace(node: rust_sitter::Node, source: &[u8]) -> Whitespace {
+            fn extract_Whitespace(
+                node: rust_sitter::tree_sitter::Node,
+                source: &[u8],
+            ) -> Whitespace {
                 let mut last_idx = node.start_byte();
                 let mut parent_cursor = node.walk();
                 let mut cursor = if parent_cursor.goto_first_child() {
@@ -190,15 +208,15 @@ mod grammar {
         }
     }
     extern "C" {
-        fn tree_sitter_test() -> rust_sitter::Language;
+        fn tree_sitter_test() -> rust_sitter::tree_sitter::Language;
     }
-    fn language() -> rust_sitter::Language {
+    fn language() -> rust_sitter::tree_sitter::Language {
         unsafe { tree_sitter_test() }
     }
     pub fn parse(
         input: &str,
     ) -> core::result::Result<NumberList, Vec<rust_sitter::errors::ParseError>> {
-        let mut parser = rust_sitter::Parser::new();
+        let mut parser = rust_sitter::tree_sitter::Parser::new();
         parser.set_language(language()).unwrap();
         let tree = parser.parse(input, None).unwrap();
         let root_node = tree.root_node();

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -3,16 +3,10 @@ use std::ops::Deref;
 pub use rust_sitter_macro::*;
 
 #[cfg(feature = "tree-sitter-standard")]
-pub use tree_sitter_runtime_standard::*;
-
-#[cfg(feature = "tree-sitter-standard")]
-use tree_sitter_runtime_standard as tree_sitter;
+pub use tree_sitter_runtime_standard as tree_sitter;
 
 #[cfg(feature = "tree-sitter-c2rust")]
-pub use tree_sitter_runtime_c2rust::*;
-
-#[cfg(feature = "tree-sitter-c2rust")]
-use tree_sitter_runtime_c2rust as tree_sitter;
+pub use tree_sitter_runtime_c2rust as tree_sitter;
 
 /// Defines the logic used to convert a node in a Tree Sitter tree to
 /// the corresponding Rust type.


### PR DESCRIPTION
Reduces pollution of Rustdoc