### PR TITLE
Expose language function as public

### DIFF
--- a/macro/src/expansion.rs
+++ b/macro/src/expansion.rs
@@ -370,7 +370,7 @@ pub fn expand_grammar(input: ItemMod) -> ItemMod {
     });
 
     transformed.push(syn::parse_quote! {
-        fn language() -> rust_sitter::tree_sitter::Language {
+        pub fn language() -> rust_sitter::tree_sitter::Language {
             unsafe { #tree_sitter_ident() }
         }
     });

--- a/macro/src/snapshots/rust_sitter_macro__tests__enum_prec_left.snap
+++ b/macro/src/snapshots/rust_sitter_macro__tests__enum_prec_left.snap
@@ -234,7 +234,7 @@ mod grammar {
     extern "C" {
         fn tree_sitter_test() -> rust_sitter::tree_sitter::Language;
     }
-    fn language() -> rust_sitter::tree_sitter::Language {
+    pub fn language() -> rust_sitter::tree_sitter::Language {
         unsafe { tree_sitter_test() }
     }
     pub fn parse(

--- a/macro/src/snapshots/rust_sitter_macro__tests__enum_recursive.snap
+++ b/macro/src/snapshots/rust_sitter_macro__tests__enum_recursive.snap
@@ -189,7 +189,7 @@ mod grammar {
     extern "C" {
         fn tree_sitter_test() -> rust_sitter::tree_sitter::Language;
     }
-    fn language() -> rust_sitter::tree_sitter::Language {
+    pub fn language() -> rust_sitter::tree_sitter::Language {
         unsafe { tree_sitter_test() }
     }
     pub fn parse(

--- a/macro/src/snapshots/rust_sitter_macro__tests__enum_transformed_fields.snap
+++ b/macro/src/snapshots/rust_sitter_macro__tests__enum_transformed_fields.snap
@@ -84,7 +84,7 @@ mod grammar {
     extern "C" {
         fn tree_sitter_test() -> rust_sitter::tree_sitter::Language;
     }
-    fn language() -> rust_sitter::tree_sitter::Language {
+    pub fn language() -> rust_sitter::tree_sitter::Language {
         unsafe { tree_sitter_test() }
     }
     pub fn parse(

--- a/macro/src/snapshots/rust_sitter_macro__tests__enum_with_named_field.snap
+++ b/macro/src/snapshots/rust_sitter_macro__tests__enum_with_named_field.snap
@@ -179,7 +179,7 @@ mod grammar {
     extern "C" {
         fn tree_sitter_test() -> rust_sitter::tree_sitter::Language;
     }
-    fn language() -> rust_sitter::tree_sitter::Language {
+    pub fn language() -> rust_sitter::tree_sitter::Language {
         unsafe { tree_sitter_test() }
     }
     pub fn parse(input: &str) -> core::result::Result<Expr, Vec<rust_sitter::errors::ParseError>> {

--- a/macro/src/snapshots/rust_sitter_macro__tests__enum_with_unamed_vector.snap
+++ b/macro/src/snapshots/rust_sitter_macro__tests__enum_with_unamed_vector.snap
@@ -150,7 +150,7 @@ mod grammar {
     extern "C" {
         fn tree_sitter_test() -> rust_sitter::tree_sitter::Language;
     }
-    fn language() -> rust_sitter::tree_sitter::Language {
+    pub fn language() -> rust_sitter::tree_sitter::Language {
         unsafe { tree_sitter_test() }
     }
     pub fn parse(input: &str) -> core::result::Result<Expr, Vec<rust_sitter::errors::ParseError>> {

--- a/macro/src/snapshots/rust_sitter_macro__tests__grammar_unboxed_field.snap
+++ b/macro/src/snapshots/rust_sitter_macro__tests__grammar_unboxed_field.snap
@@ -157,7 +157,7 @@ mod grammar {
     extern "C" {
         fn tree_sitter_test() -> rust_sitter::tree_sitter::Language;
     }
-    fn language() -> rust_sitter::tree_sitter::Language {
+    pub fn language() -> rust_sitter::tree_sitter::Language {
         unsafe { tree_sitter_test() }
     }
     pub fn parse(

--- a/macro/src/snapshots/rust_sitter_macro__tests__spanned_in_vec.snap
+++ b/macro/src/snapshots/rust_sitter_macro__tests__spanned_in_vec.snap
@@ -228,7 +228,7 @@ mod grammar {
     extern "C" {
         fn tree_sitter_test() -> rust_sitter::tree_sitter::Language;
     }
-    fn language() -> rust_sitter::tree_sitter::Language {
+    pub fn language() -> rust_sitter::tree_sitter::Language {
         unsafe { tree_sitter_test() }
     }
     pub fn parse(

--- a/macro/src/snapshots/rust_sitter_macro__tests__struct_extra.snap
+++ b/macro/src/snapshots/rust_sitter_macro__tests__struct_extra.snap
@@ -158,7 +158,7 @@ mod grammar {
     extern "C" {
         fn tree_sitter_test() -> rust_sitter::tree_sitter::Language;
     }
-    fn language() -> rust_sitter::tree_sitter::Language {
+    pub fn language() -> rust_sitter::tree_sitter::Language {
         unsafe { tree_sitter_test() }
     }
     pub fn parse(

--- a/macro/src/snapshots/rust_sitter_macro__tests__struct_optional.snap
+++ b/macro/src/snapshots/rust_sitter_macro__tests__struct_optional.snap
@@ -199,7 +199,7 @@ mod grammar {
     extern "C" {
         fn tree_sitter_test() -> rust_sitter::tree_sitter::Language;
     }
-    fn language() -> rust_sitter::tree_sitter::Language {
+    pub fn language() -> rust_sitter::tree_sitter::Language {
         unsafe { tree_sitter_test() }
     }
     pub fn parse(

--- a/macro/src/snapshots/rust_sitter_macro__tests__struct_repeat.snap
+++ b/macro/src/snapshots/rust_sitter_macro__tests__struct_repeat.snap
@@ -226,7 +226,7 @@ mod grammar {
     extern "C" {
         fn tree_sitter_test() -> rust_sitter::tree_sitter::Language;
     }
-    fn language() -> rust_sitter::tree_sitter::Language {
+    pub fn language() -> rust_sitter::tree_sitter::Language {
         unsafe { tree_sitter_test() }
     }
     pub fn parse(


### PR DESCRIPTION
This is a one-line change to expose the `language` function in the macro expansion as public. This is useful if you want to get the `Language` generated by rust-sitter and use it to do more complicated things like incremental parsing or syntax highlighting (using tree-sitter-highlight).