### PR TITLE
Suppress all C warnings

### DIFF
--- a/tool/src/lib.rs
+++ b/tool/src/lib.rs
@@ -94,9 +94,7 @@ pub fn build_parsers(root_file: &Path) {
         cc::Build::new()
             .include(&dir)
             .include(&sysroot_dir)
-            .flag_if_supported("-Wno-unused-label")
-            .flag_if_supported("-Wno-unused-but-set-variable")
-            .flag_if_supported("-Wno-unknown-warning-option")
+            .flag_if_supported("-Wno-everthing")
             .file(dir.path().join("parser.c"))
             .compile(&grammar_name);
     });


### PR DESCRIPTION
This suppresses all warnings in the generated C code by adding the "-Wno-everything" flag. These errors aren't really fixable from the user perspective and just clutter up the terminal.