### PR TITLE
Fix typo in warning suppression

### DIFF
--- a/tool/src/lib.rs
+++ b/tool/src/lib.rs
@@ -94,7 +94,7 @@ pub fn build_parsers(root_file: &Path) {
         cc::Build::new()
             .include(&dir)
             .include(&sysroot_dir)
-            .flag_if_supported("-Wno-everthing")
+            .flag_if_supported("-Wno-everything")
             .file(dir.path().join("parser.c"))
             .compile(&grammar_name);
     });


### PR DESCRIPTION
My previous pull request had a typo, which meant it didn't actually work