### PR TITLE
feat: improve the ergonomics of empty leaf nodes

### DIFF
--- a/macro/src/lib.rs
+++ b/macro/src/lib.rs
@@ -50,13 +50,31 @@ pub fn extra(
 /// such as a number, then the `transform` argument can be used to specify a function
 /// that will be called with the token's text.
 ///
-/// ## Example
+/// The attribute can also be applied to a struct or enum variant with no fields.
+///
+/// ## Examples
+///
+/// Using the `leaf` attribute on a field:
 /// ```ignore
 /// Number(
 ///     #[rust_sitter::leaf(pattern = r"\d+", transform = |v| v.parse().unwrap())]
 ///     u32
 /// )
 /// ```
+///
+/// Using the attribute on a unit struct or unit enum variant:
+/// ```ignore
+/// #[rust_sitter::leaf(text = "9")]
+/// struct BigDigit;
+///
+/// enum SmallDigit {
+///     #[rust_sitter::leaf(text = "0")]
+///     Zero,
+///     #[rust_sitter::leaf(text = "1")]
+///     One,
+/// }
+/// ```
+///
 pub fn leaf(
     _attr: proc_macro::TokenStream,
     item: proc_macro::TokenStream,

--- a/tool/src/expansion.rs
+++ b/tool/src/expansion.rs
@@ -299,7 +299,7 @@ fn gen_struct_or_variant(
                     .map(|v| v.to_string())
                     .unwrap_or(format!("{i}"));
 
-                Some(gen_field_optional(&path, &field, word_rule, out, ident_str))
+                Some(gen_field_optional(&path, field, word_rule, out, ident_str))
             }
         })
         .collect::<Vec<Value>>();


### PR DESCRIPTION
# Objective
- Currently in Rust Sitter, writing the AST can quickly become an ergonomics nightmare as all leaf nodes must be fields.
- This PR improves this situation by allowing the `#[rust_sitter::leaf]` attribute on structs and enum variants with no fields; the changes are summarised below:

```rust
// old syntax:
struct Zero(#[rust_sitter::leaf(text = "0")] ());

enum Operator {
    Add(#[rust_sitter::leaf(text = "+")] ()),
    Sub(#[rust_sitter::leaf(text = "-")] ()),
    Mul(#[rust_sitter::leaf(text = "*")] ()),
    Div(#[rust_sitter::leaf(text = "/")] ()),
}

// new syntax:
#[rust_sitter::leaf(text = "0")]
struct Zero;

enum Operator {
    #[rust_sitter::leaf(text = "+")]
    Add,
    #[rust_sitter::leaf(text = "-")]
    Sub,
    #[rust_sitter::leaf(text = "*")]
    Mul,
    #[rust_sitter::leaf(text = "/")]
    Div,
}
```