### PR TITLE
feat: use `syn::Error` instead of panicking to improve error reporting

### DIFF
--- a/macro/src/errors.rs
+++ b/macro/src/errors.rs
@@ -1,0 +1,62 @@
+use std::marker::PhantomData;
+
+/// An iterator that maps [`Result`]s to their [`Ok`] values
+/// and stores combined errors within itself.
+struct CollectingShunt<'a, I, A> {
+    iter: I,
+    err: &'a mut Option<syn::Error>,
+    _marker: PhantomData<fn() -> A>,
+}
+
+impl<'a, I, A> Iterator for CollectingShunt<'a, I, A>
+where
+    I: Iterator<Item = syn::Result<A>>,
+{
+    type Item = A;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        match self.iter.next() {
+            Some(Ok(x)) => Some(x),
+            Some(Err(another)) => {
+                match self.err {
+                    Some(x) => x.combine(another),
+                    ref mut x => **x = Some(another),
+                }
+                None
+            }
+            _ => None,
+        }
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let (_, upper) = self.iter.size_hint();
+        (0, upper)
+    }
+}
+
+pub trait IteratorExt<A>: Iterator<Item = syn::Result<A>> {
+    /// Reduces an iterator with items of type [`syn::Result<T>`] into one large collection,
+    /// [combining] errors and [collecting] successes.
+    ///
+    /// [combining]: syn::Error::combine
+    /// [collecting]: FromIterator
+    fn sift<T>(self) -> syn::Result<T>
+    where
+        Self: Sized,
+        T: FromIterator<A>,
+    {
+        let mut err = None;
+        let iter = CollectingShunt {
+            iter: self,
+            err: &mut err,
+            _marker: PhantomData,
+        };
+        let collection = iter.collect();
+        match err {
+            Some(error) => Err(error),
+            None => Ok(collection),
+        }
+    }
+}
+
+impl<A, T> IteratorExt<A> for T where T: Iterator<Item = syn::Result<A>> {}


### PR DESCRIPTION
# Objective
- Often when working with Rust Sitter, error spans are redirected to call site because we panic instead of propagating errors, this can make it hard to discern where the fault lies. This PR uses `syn::Error` to keep track of error spans where necessary.

# Future Work
- This implementation is not complete because `syn::parse_quote!` panics when it receives invalid tokens, I can think of three ways to rectify this error escape hatch:
  1. roll out our own `parse_quote!` implementation that returns a `Result`.
  2. more carefully ensure the tokens we pass to `parse_quote!` are valid.
  3. refactor the codebase to use `quote::quote!` instead of `parse_quote!` and pass around `proc_macro2::TokenStream` instead of using parsed types. this does leave us without type checking as we compose the final module but it propagates syntactic errors to `rustc`'s parser which provides much better diagnostics than `syn`'s solution.