### PR TITLE
#14 Deduplicate field logic into runtime utility

### DIFF
--- a/macro/src/expansion.rs
+++ b/macro/src/expansion.rs
@@ -15,7 +15,7 @@ fn is_sitter_attr(attr: &Attribute) -> bool {
         .unwrap_or(false)
 }
 
-enum ParamOrField {
+pub enum ParamOrField {
     Param(Expr),
     Field(FieldValue),
 }
@@ -29,8 +29,7 @@ impl ToTokens for ParamOrField {
     }
 }
 
-fn gen_field(path: String, ident_str: String, leaf: Field, out: &mut Vec<Item>) {
-    let extract_ident = Ident::new(&format!("extract_{path}"), Span::call_site());
+fn gen_field(ident_str: String, leaf: Field) -> Expr {
     let leaf_type = leaf.ty;
 
     let leaf_attr = leaf
@@ -49,11 +48,7 @@ fn gen_field(path: String, ident_str: String, leaf: Field, out: &mut Vec<Item>) 
             .map(|p| p.expr.clone())
     });
 
-    let mut skip_over = HashSet::new();
-    skip_over.insert("Spanned");
-    skip_over.insert("Box");
-
-    let (leaf_stmts, leaf_expr): (Vec<Stmt>, Expr) = match transform_param {
+    let (leaf_type, closure_expr): (Type, Expr) = match transform_param {
         Some(closure) => {
             let mut non_leaf = HashSet::new();
             non_leaf.insert("Spanned");
@@ -61,112 +56,70 @@ fn gen_field(path: String, ident_str: String, leaf: Field, out: &mut Vec<Item>) 
             non_leaf.insert("Option");
             non_leaf.insert("Vec");
             let wrapped_leaf_type = wrap_leaf_type(&leaf_type, &non_leaf);
-
-            (
-                vec![],
-                syn::parse_quote!(<#wrapped_leaf_type as rust_sitter::Extract<_>>::extract(node, source, *last_idx, Some(&#closure))),
-            )
+            (wrapped_leaf_type, syn::parse_quote!(Some(&#closure)))
         }
-        None => (
-            vec![],
-            syn::parse_quote!(<#leaf_type as rust_sitter::Extract<_>>::extract(node, source, *last_idx, None)),
-        ),
+        None => (leaf_type, syn::parse_quote!(None)),
     };
 
-    // TODO: leaf_stmts is always empty... for now. Are there plans for this? Otherwise the code can be simplified even further!
-    out.push(syn::parse_quote! {
-        #[allow(non_snake_case)]
-        #[allow(clippy::unused_unit)]
-        fn #extract_ident(cursor_opt: &mut Option<rust_sitter::tree_sitter::TreeCursor>, source: &[u8], last_idx: &mut usize) -> #leaf_type {
-            #(#leaf_stmts)*
-
-            rust_sitter::__private::extract_field(cursor_opt, last_idx, #ident_str, move |node, last_idx| #leaf_expr)
-        }
-    });
+    syn::parse_quote!({
+        ::rust_sitter::__private::extract_field::<#leaf_type,_>(cursor, source, last_idx, #ident_str, #closure_expr)
+    })
 }
 
 fn gen_struct_or_variant(
-    path: String,
     fields: Fields,
     variant_ident: Option<Ident>,
     containing_type: Ident,
     container_attrs: Vec<Attribute>,
-    out: &mut Vec<Item>,
-) -> Result<()> {
-    if fields == Fields::Unit {
-        let dummy_field = Field {
-            attrs: container_attrs,
-            vis: Visibility::Inherited,
-            ident: None,
-            colon_token: None,
-            ty: Type::Verbatim(quote!(())), // unit type.
+) -> Result<Expr> {
+    let children_parsed = if fields == Fields::Unit {
+        let expr = {
+            let dummy_field = Field {
+                attrs: container_attrs,
+                vis: Visibility::Inherited,
+                ident: None,
+                colon_token: None,
+                ty: Type::Verbatim(quote!(())), // unit type.
+            };
+
+            gen_field("unit".to_string(), dummy_field)
         };
-        gen_field(format!("{path}_unit"), "unit".to_owned(), dummy_field, out);
+        vec![ParamOrField::Param(expr)]
     } else {
-        fields.iter().enumerate().for_each(|(i, field)| {
-            let ident_str = field
-                .ident
-                .as_ref()
-                .map(|v| v.to_string())
-                .unwrap_or(format!("{i}"));
+        fields
+            .iter()
+            .enumerate()
+            .map(|(i, field)| {
+                let expr = if let Some(skip_attrs) = field
+                    .attrs
+                    .iter()
+                    .find(|attr| attr.path == syn::parse_quote!(rust_sitter::skip))
+                {
+                    skip_attrs.parse_args::<syn::Expr>()?
+                } else {
+                    let ident_str = field
+                        .ident
+                        .as_ref()
+                        .map(|v| v.to_string())
+                        .unwrap_or(format!("{i}"));
 
-            if !field
-                .attrs
-                .iter()
-                .any(|attr| attr.path == syn::parse_quote!(rust_sitter::skip))
-            {
-                gen_field(
-                    format!("{}_{}", path, ident_str),
-                    ident_str,
-                    field.clone(),
-                    out,
-                );
-            }
-        });
-    }
+                    gen_field(ident_str, field.clone())
+                };
 
-    let extract_ident = Ident::new(&format!("extract_{path}"), Span::call_site());
-
-    let mut have_named_field = false;
-
-    let children_parsed = fields
-        .iter()
-        .enumerate()
-        .map(|(i, field)| {
-            let expr = if let Some(skip_attrs) = field
-                .attrs
-                .iter()
-                .find(|attr| attr.path == syn::parse_quote!(rust_sitter::skip))
-            {
-                skip_attrs.parse_args::<syn::Expr>()?
-            } else {
-                let ident_str = field
-                    .ident
-                    .as_ref()
-                    .map(|v| v.to_string())
-                    .unwrap_or(format!("{i}"));
-
-                let ident = Ident::new(&format!("extract_{path}_{ident_str}"), Span::call_site());
-
-                syn::parse_quote! {
-                    #ident(cursor, source, last_idx)
-                }
-            };
-
-            let field = if let Some(field_name) = &field.ident {
-                have_named_field = true;
-                ParamOrField::Field(FieldValue {
-                    attrs: vec![],
-                    member: Member::Named(field_name.clone()),
-                    colon_token: Some(Token![:](Span::call_site())),
-                    expr,
-                })
-            } else {
-                ParamOrField::Param(expr)
-            };
-            Ok(field)
-        })
-        .sift::<Vec<ParamOrField>>()?;
+                let field = if let Some(field_name) = &field.ident {
+                    ParamOrField::Field(FieldValue {
+                        attrs: vec![],
+                        member: Member::Named(field_name.clone()),
+                        colon_token: Some(Token![:](Span::call_site())),
+                        expr,
+                    })
+                } else {
+                    ParamOrField::Param(expr)
+                };
+                Ok(field)
+            })
+            .sift::<Vec<ParamOrField>>()?
+    };
 
     let construct_name = match variant_ident {
         Some(ident) => quote! {
@@ -180,10 +133,13 @@ fn gen_struct_or_variant(
     let construct_expr = {
         match &fields {
             Fields::Unit => {
-                let ident = Ident::new(&format!("extract_{path}_unit"), Span::call_site());
+                let ParamOrField::Param(ref expr) = children_parsed[0] else {
+                    unreachable!()
+                };
+
                 quote! {
                     {
-                        #ident(cursor, source, last_idx);
+                        #expr;
                         #construct_name
                     }
                 }
@@ -201,14 +157,9 @@ fn gen_struct_or_variant(
         }
     };
 
-    out.push(syn::parse_quote! {
-        #[allow(non_snake_case)]
-        fn #extract_ident(node: rust_sitter::tree_sitter::Node, source: &[u8]) -> #containing_type {
-            rust_sitter::__private::extract_struct_or_variant(node, move |cursor, last_idx| #construct_expr)
-        }
-    });
-
-    Ok(())
+    Ok(
+        syn::parse_quote!(::rust_sitter::__private::extract_struct_or_variant(node, move |cursor, last_idx| #construct_expr)),
+    )
 }
 
 pub fn expand_grammar(input: ItemMod) -> Result<ItemMod> {
@@ -272,102 +223,82 @@ pub fn expand_grammar(input: ItemMod) -> Result<ItemMod> {
         .cloned()
         .map(|c| match c {
             Item::Enum(mut e) => {
-                let mut impl_body = vec![];
-                e.variants.iter().map(|v| {
-                    gen_struct_or_variant(
-                        format!("{}_{}", e.ident, v.ident),
-                        v.fields.clone(),
-                        Some(v.ident.clone()),
-                        e.ident.clone(),
-                        v.attrs.clone(),
-                        &mut impl_body,
-                    )
-                }).sift::<()>()?;
-
-                let match_cases: Vec<Arm> = e
-                    .variants
-                    .iter()
-                    .map(|v| {
+                    let match_cases: Vec<Arm> = e.variants.iter().map(|v| {
                         let variant_path = format!("{}_{}", e.ident, v.ident);
-                        let extract_ident =
-                            Ident::new(&format!("extract_{variant_path}"), Span::call_site());
-                        syn::parse_quote! {
-                            #variant_path => return #extract_ident(n, source)
-                        }
-                    })
-                    .collect();
 
-                e.attrs.retain(|a| !is_sitter_attr(a));
-                e.variants.iter_mut().for_each(|v| {
-                    v.attrs.retain(|a| !is_sitter_attr(a));
-                    v.fields.iter_mut().for_each(|f| {
-                        f.attrs.retain(|a| !is_sitter_attr(a));
+                        let extract_expr = gen_struct_or_variant(
+                            v.fields.clone(),
+                            Some(v.ident.clone()),
+                            e.ident.clone(),
+                            v.attrs.clone(),
+                        )?;
+                        Ok(syn::parse_quote! {
+                            #variant_path => return #extract_expr
+                        })
+                    }).sift::<Vec<Arm>>()?;
+
+                    e.attrs.retain(|a| !is_sitter_attr(a));
+                    e.variants.iter_mut().for_each(|v| {
+                        v.attrs.retain(|a| !is_sitter_attr(a));
+                        v.fields.iter_mut().for_each(|f| {
+                            f.attrs.retain(|a| !is_sitter_attr(a));
+                        });
                     });
-                });
 
-                let enum_name = &e.ident;
-                let extract_impl: Item = syn::parse_quote! {
-                    impl rust_sitter::Extract<#enum_name> for #enum_name {
-                        type LeafFn = ();
+                    let enum_name = &e.ident;
+                    let extract_impl: Item = syn::parse_quote! {
+                        impl ::rust_sitter::Extract<#enum_name> for #enum_name {
+                            type LeafFn = ();
 
-                        #[allow(non_snake_case)]
-                        fn extract(node: Option<rust_sitter::tree_sitter::Node>, source: &[u8], _last_idx: usize, _leaf_fn: Option<&Self::LeafFn>) -> Self {
-                            let node = node.unwrap();
-                            #(#impl_body)*
+                            #[allow(non_snake_case)]
+                            fn extract(node: Option<::rust_sitter::tree_sitter::Node>, source: &[u8], _last_idx: usize, _leaf_fn: Option<&Self::LeafFn>) -> Self {
+                                let node = node.unwrap();
 
-                            let mut cursor = node.walk();
-                            assert!(cursor.goto_first_child());
-                            loop {
-                                let n = cursor.node();
-                                match n.kind() {
-                                    #(#match_cases),*,
-                                    _ => if !cursor.goto_next_sibling() {
-                                        panic!("Could not find a child corresponding to any enum branch")
+                                let mut cursor = node.walk();
+                                assert!(cursor.goto_first_child(), "Could not find a child corresponding to any enum branch");
+                                loop {
+                                    let node = cursor.node();
+                                    match node.kind() {
+                                        #(#match_cases),*,
+                                        _ => if !cursor.goto_next_sibling() {
+                                            panic!("Could not find a child corresponding to any enum branch")
+                                        }
                                     }
                                 }
                             }
                         }
-                    }
-                };
-
-                Ok(vec![Item::Enum(e), extract_impl])
+                    };
+                    Ok(vec![Item::Enum(e), extract_impl])
             }
 
             Item::Struct(mut s) => {
-                let mut impl_body = vec![];
+                    let struct_name = &s.ident;
+                    let extract_expr = gen_struct_or_variant(
+                        s.fields.clone(),
+                        None,
+                        s.ident.clone(),
+                        s.attrs.clone(),
+                    )?;
 
-                gen_struct_or_variant(
-                    s.ident.to_string(),
-                    s.fields.clone(),
-                    None,
-                    s.ident.clone(),
-                    s.attrs.clone(),
-                    &mut impl_body,
-                )?;
+                    s.attrs.retain(|a| !is_sitter_attr(a));
+                    s.fields.iter_mut().for_each(|f| {
+                        f.attrs.retain(|a| !is_sitter_attr(a));
+                    });
 
-                s.attrs.retain(|a| !is_sitter_attr(a));
-                s.fields.iter_mut().for_each(|f| {
-                    f.attrs.retain(|a| !is_sitter_attr(a));
-                });
 
-                let struct_name = &s.ident;
-                let extract_ident =
-                    Ident::new(&format!("extract_{struct_name}"), Span::call_site());
+                    let extract_impl: Item = syn::parse_quote! {
+                        impl ::rust_sitter::Extract<#struct_name> for #struct_name {
+                            type LeafFn = ();
 
-                let extract_impl: Item = syn::parse_quote! {
-                    impl rust_sitter::Extract<#struct_name> for #struct_name {
-                        type LeafFn = ();
-
-                        #[allow(non_snake_case)]
-                        fn extract(node: Option<rust_sitter::tree_sitter::Node>, source: &[u8], last_idx: usize, _leaf_fn: Option<&Self::LeafFn>) -> Self {
-                            let node = node.unwrap();
-                            #(#impl_body)*
-                            #extract_ident(node, source)
+                            #[allow(non_snake_case)]
+                            fn extract(node: Option<::rust_sitter::tree_sitter::Node>, source: &[u8], last_idx: usize, _leaf_fn: Option<&Self::LeafFn>) -> Self {
+                                let node = node.unwrap();
+                                #extract_expr
+                            }
                         }
-                    }
-                };
+                    };
 
-                Ok(vec![Item::Struct(s), extract_impl])
+                    Ok(vec![Item::Struct(s), extract_impl])
             }
 
             o => Ok(vec![o]),
@@ -378,36 +309,23 @@ pub fn expand_grammar(input: ItemMod) -> Result<ItemMod> {
 
     transformed.push(syn::parse_quote! {
         extern "C" {
-            fn #tree_sitter_ident() -> rust_sitter::tree_sitter::Language;
+            fn #tree_sitter_ident() -> ::rust_sitter::tree_sitter::Language;
         }
     });
 
     transformed.push(syn::parse_quote! {
-        pub fn language() -> rust_sitter::tree_sitter::Language {
+        pub fn language() -> ::rust_sitter::tree_sitter::Language {
             unsafe { #tree_sitter_ident() }
         }
     });
 
+    let root_type_docstr = format!("[`{root_type}`]");
     transformed.push(syn::parse_quote! {
-      pub fn parse(input: &str) -> core::result::Result<#root_type, Vec<rust_sitter::errors::ParseError>> {
-          let mut parser = rust_sitter::tree_sitter::Parser::new();
-          parser.set_language(language()).unwrap();
-          let tree = parser.parse(input, None).unwrap();
-          let root_node = tree.root_node();
-
-          if root_node.has_error() {
-              let mut errors = vec![];
-              rust_sitter::errors::collect_parsing_errors(
-                  &root_node,
-                  input.as_bytes(),
-                  &mut errors,
-              );
-
-              Err(errors)
-          } else {
-              use rust_sitter::Extract;
-              Ok(<#root_type as rust_sitter::Extract<_>>::extract(Some(root_node), input.as_bytes(), 0, None))
-          }
+    /// Parse an input string according to the grammar. Returns either any parsing errors that happened, or a
+    #[doc = #root_type_docstr]
+    /// instance containing the parsed structured data.
+      pub fn parse(input: &str) -> core::result::Result<#root_type, Vec<::rust_sitter::errors::ParseError>> {
+        ::rust_sitter::__private::parse::<#root_type>(input, language)
       }
   });
 

--- a/macro/src/expansion.rs
+++ b/macro/src/expansion.rs
@@ -80,7 +80,7 @@ fn gen_field(path: String, ident_str: String, leaf: Field, out: &mut Vec<Item>) 
         fn #extract_ident(cursor_opt: &mut Option<rust_sitter::tree_sitter::TreeCursor>, source: &[u8], last_idx: &mut usize) -> #leaf_type {
             #(#leaf_stmts)*
 
-            rust_sitter::extract_field(cursor_opt, last_idx, #ident_str, move |node, last_idx| #leaf_expr)
+            rust_sitter::__private::extract_field(cursor_opt, last_idx, #ident_str, move |node, last_idx| #leaf_expr)
         }
     });
 }
@@ -204,7 +204,7 @@ fn gen_struct_or_variant(
     out.push(syn::parse_quote! {
         #[allow(non_snake_case)]
         fn #extract_ident(node: rust_sitter::tree_sitter::Node, source: &[u8]) -> #containing_type {
-            rust_sitter::extract_struct_or_variant(node, move |cursor, last_idx| #construct_expr)
+            rust_sitter::__private::extract_struct_or_variant(node, move |cursor, last_idx| #construct_expr)
         }
     });
 

--- a/macro/src/snapshots/rust_sitter_macro__tests__enum_prec_left.snap
+++ b/macro/src/snapshots/rust_sitter_macro__tests__enum_prec_left.snap
@@ -1,124 +1,69 @@
 ---
 source: macro/src/lib.rs
-expression: "rustfmt_code(&expand_grammar(parse_quote! {\n                            #[rust_sitter :: grammar(\"test\")] mod grammar\n                            {\n                                #[rust_sitter :: language] pub enum Expression\n                                {\n                                    Number(#[rust_sitter ::\n                                    leaf(pattern = r\"\\d+\", transform = | v |\n                                    v.parse().unwrap())] i32), #[rust_sitter :: prec_left(1)]\n                                    Sub(Box < Expression >, #[rust_sitter :: leaf(text = \"-\")]\n                                    (), Box < Expression >),\n                                }\n                            }\n                        }).to_token_stream().to_string())"
+expression: "rustfmt_code(&expand_grammar(parse_quote! {\n                                #[rust_sitter :: grammar(\"test\")] mod grammar\n                                {\n                                    #[rust_sitter :: language] pub enum Expression\n                                    {\n                                        Number(#[rust_sitter ::\n                                        leaf(pattern = r\"\\d+\", transform = | v |\n                                        v.parse().unwrap())] i32), #[rust_sitter :: prec_left(1)]\n                                        Sub(Box < Expression >, #[rust_sitter :: leaf(text = \"-\")]\n                                        (), Box < Expression >),\n                                    }\n                                }\n                            })?.to_token_stream().to_string())"
 ---
 mod grammar {
     pub enum Expression {
         Number(i32),
         Sub(Box<Expression>, (), Box<Expression>),
     }
-    impl rust_sitter::Extract<Expression> for Expression {
+    impl ::rust_sitter::Extract<Expression> for Expression {
         type LeafFn = ();
         #[allow(non_snake_case)]
         fn extract(
-            node: Option<rust_sitter::tree_sitter::Node>,
+            node: Option<::rust_sitter::tree_sitter::Node>,
             source: &[u8],
             _last_idx: usize,
             _leaf_fn: Option<&Self::LeafFn>,
         ) -> Self {
             let node = node.unwrap();
-            #[allow(non_snake_case)]
-            #[allow(clippy::unused_unit)]
-            fn extract_Expression_Number_0(
-                cursor_opt: &mut Option<rust_sitter::tree_sitter::TreeCursor>,
-                source: &[u8],
-                last_idx: &mut usize,
-            ) -> i32 {
-                rust_sitter::__private::extract_field(
-                    cursor_opt,
-                    last_idx,
-                    "0",
-                    move |node, last_idx| {
-                        <rust_sitter::WithLeaf<i32> as rust_sitter::Extract<_>>::extract(
-                            node,
-                            source,
-                            *last_idx,
-                            Some(&|v| v.parse().unwrap()),
-                        )
-                    },
-                )
-            }
-            #[allow(non_snake_case)]
-            fn extract_Expression_Number(
-                node: rust_sitter::tree_sitter::Node,
-                source: &[u8],
-            ) -> Expression {
-                rust_sitter::__private::extract_struct_or_variant(node, move |cursor, last_idx| {
-                    Expression::Number(extract_Expression_Number_0(cursor, source, last_idx))
-                })
-            }
-            #[allow(non_snake_case)]
-            #[allow(clippy::unused_unit)]
-            fn extract_Expression_Sub_0(
-                cursor_opt: &mut Option<rust_sitter::tree_sitter::TreeCursor>,
-                source: &[u8],
-                last_idx: &mut usize,
-            ) -> Box<Expression> {
-                rust_sitter::__private::extract_field(
-                    cursor_opt,
-                    last_idx,
-                    "0",
-                    move |node, last_idx| {
-                        <Box<Expression> as rust_sitter::Extract<_>>::extract(
-                            node, source, *last_idx, None,
-                        )
-                    },
-                )
-            }
-            #[allow(non_snake_case)]
-            #[allow(clippy::unused_unit)]
-            fn extract_Expression_Sub_1(
-                cursor_opt: &mut Option<rust_sitter::tree_sitter::TreeCursor>,
-                source: &[u8],
-                last_idx: &mut usize,
-            ) -> () {
-                rust_sitter::__private::extract_field(
-                    cursor_opt,
-                    last_idx,
-                    "1",
-                    move |node, last_idx| {
-                        <() as rust_sitter::Extract<_>>::extract(node, source, *last_idx, None)
-                    },
-                )
-            }
-            #[allow(non_snake_case)]
-            #[allow(clippy::unused_unit)]
-            fn extract_Expression_Sub_2(
-                cursor_opt: &mut Option<rust_sitter::tree_sitter::TreeCursor>,
-                source: &[u8],
-                last_idx: &mut usize,
-            ) -> Box<Expression> {
-                rust_sitter::__private::extract_field(
-                    cursor_opt,
-                    last_idx,
-                    "2",
-                    move |node, last_idx| {
-                        <Box<Expression> as rust_sitter::Extract<_>>::extract(
-                            node, source, *last_idx, None,
-                        )
-                    },
-                )
-            }
-            #[allow(non_snake_case)]
-            fn extract_Expression_Sub(
-                node: rust_sitter::tree_sitter::Node,
-                source: &[u8],
-            ) -> Expression {
-                rust_sitter::__private::extract_struct_or_variant(node, move |cursor, last_idx| {
-                    Expression::Sub(
-                        extract_Expression_Sub_0(cursor, source, last_idx),
-                        extract_Expression_Sub_1(cursor, source, last_idx),
-                        extract_Expression_Sub_2(cursor, source, last_idx),
-                    )
-                })
-            }
             let mut cursor = node.walk();
-            assert!(cursor.goto_first_child());
+            assert!(
+                cursor.goto_first_child(),
+                "Could not find a child corresponding to any enum branch"
+            );
             loop {
-                let n = cursor.node();
-                match n.kind() {
-                    "Expression_Number" => return extract_Expression_Number(n, source),
-                    "Expression_Sub" => return extract_Expression_Sub(n, source),
+                let node = cursor.node();
+                match node.kind() {
+                    "Expression_Number" => {
+                        return ::rust_sitter::__private::extract_struct_or_variant(
+                            node,
+                            move |cursor, last_idx| {
+                                Expression::Number({
+                                    ::rust_sitter::__private::extract_field::<
+                                        rust_sitter::WithLeaf<i32>,
+                                        _,
+                                    >(
+                                        cursor, source, last_idx, "0", Some(&|v| v.parse().unwrap())
+                                    )
+                                })
+                            },
+                        )
+                    }
+                    "Expression_Sub" => {
+                        return ::rust_sitter::__private::extract_struct_or_variant(
+                            node,
+                            move |cursor, last_idx| {
+                                Expression::Sub(
+                                    {
+                                        ::rust_sitter::__private::extract_field::<Box<Expression>, _>(
+                                            cursor, source, last_idx, "0", None,
+                                        )
+                                    },
+                                    {
+                                        ::rust_sitter::__private::extract_field::<(), _>(
+                                            cursor, source, last_idx, "1", None,
+                                        )
+                                    },
+                                    {
+                                        ::rust_sitter::__private::extract_field::<Box<Expression>, _>(
+                                            cursor, source, last_idx, "2", None,
+                                        )
+                                    },
+                                )
+                            },
+                        )
+                    }
                     _ => {
                         if !cursor.goto_next_sibling() {
                             panic!("Could not find a child corresponding to any enum branch")
@@ -129,31 +74,18 @@ mod grammar {
         }
     }
     extern "C" {
-        fn tree_sitter_test() -> rust_sitter::tree_sitter::Language;
+        fn tree_sitter_test() -> ::rust_sitter::tree_sitter::Language;
     }
-    pub fn language() -> rust_sitter::tree_sitter::Language {
+    pub fn language() -> ::rust_sitter::tree_sitter::Language {
         unsafe { tree_sitter_test() }
     }
+    #[doc = r" Parse an input string according to the grammar. Returns either any parsing errors that happened, or a"]
+    #[doc = "[`Expression`]"]
+    #[doc = r" instance containing the parsed structured data."]
     pub fn parse(
         input: &str,
-    ) -> core::result::Result<Expression, Vec<rust_sitter::errors::ParseError>> {
-        let mut parser = rust_sitter::tree_sitter::Parser::new();
-        parser.set_language(language()).unwrap();
-        let tree = parser.parse(input, None).unwrap();
-        let root_node = tree.root_node();
-        if root_node.has_error() {
-            let mut errors = vec![];
-            rust_sitter::errors::collect_parsing_errors(&root_node, input.as_bytes(), &mut errors);
-            Err(errors)
-        } else {
-            use rust_sitter::Extract;
-            Ok(<Expression as rust_sitter::Extract<_>>::extract(
-                Some(root_node),
-                input.as_bytes(),
-                0,
-                None,
-            ))
-        }
+    ) -> core::result::Result<Expression, Vec<::rust_sitter::errors::ParseError>> {
+        ::rust_sitter::__private::parse::<Expression>(input, language)
     }
 }
 

--- a/macro/src/snapshots/rust_sitter_macro__tests__enum_prec_left.snap
+++ b/macro/src/snapshots/rust_sitter_macro__tests__enum_prec_left.snap
@@ -24,57 +24,28 @@ mod grammar {
                 source: &[u8],
                 last_idx: &mut usize,
             ) -> i32 {
-                if let Some(cursor) = cursor_opt.as_mut() {
-                    loop {
-                        let n = cursor.node();
-                        if let Some(name) = cursor.field_name() {
-                            if name == "0" {
-                                let node: Option<rust_sitter::tree_sitter::Node> = Some(n);
-                                let out = < rust_sitter :: WithLeaf < i32 > as rust_sitter :: Extract < _ > > :: extract (node , source , * last_idx , Some (& | v | v . parse () . unwrap ())) ;
-                                if !cursor.goto_next_sibling() {
-                                    *cursor_opt = None;
-                                };
-                                *last_idx = n.end_byte();
-                                return out;
-                            } else {
-                                let node: Option<rust_sitter::tree_sitter::Node> = None;
-                                return < rust_sitter :: WithLeaf < i32 > as rust_sitter :: Extract < _ > > :: extract (node , source , * last_idx , Some (& | v | v . parse () . unwrap ())) ;
-                            }
-                        } else {
-                            *last_idx = n.end_byte();
-                        }
-                        if !cursor.goto_next_sibling() {
-                            let node: Option<rust_sitter::tree_sitter::Node> = None;
-                            return < rust_sitter :: WithLeaf < i32 > as rust_sitter :: Extract < _ > > :: extract (node , source , * last_idx , Some (& | v | v . parse () . unwrap ())) ;
-                        }
-                    }
-                } else {
-                    let node: Option<rust_sitter::tree_sitter::Node> = None;
-                    return <rust_sitter::WithLeaf<i32> as rust_sitter::Extract<_>>::extract(
-                        node,
-                        source,
-                        *last_idx,
-                        Some(&|v| v.parse().unwrap()),
-                    );
-                }
+                rust_sitter::__private::extract_field(
+                    cursor_opt,
+                    last_idx,
+                    "0",
+                    move |node, last_idx| {
+                        <rust_sitter::WithLeaf<i32> as rust_sitter::Extract<_>>::extract(
+                            node,
+                            source,
+                            *last_idx,
+                            Some(&|v| v.parse().unwrap()),
+                        )
+                    },
+                )
             }
             #[allow(non_snake_case)]
             fn extract_Expression_Number(
                 node: rust_sitter::tree_sitter::Node,
                 source: &[u8],
             ) -> Expression {
-                let mut last_idx = node.start_byte();
-                let mut parent_cursor = node.walk();
-                let mut cursor = if parent_cursor.goto_first_child() {
-                    Some(parent_cursor)
-                } else {
-                    None
-                };
-                Expression::Number(extract_Expression_Number_0(
-                    &mut cursor,
-                    source,
-                    &mut last_idx,
-                ))
+                rust_sitter::__private::extract_struct_or_variant(node, move |cursor, last_idx| {
+                    Expression::Number(extract_Expression_Number_0(cursor, source, last_idx))
+                })
             }
             #[allow(non_snake_case)]
             #[allow(clippy::unused_unit)]
@@ -83,42 +54,16 @@ mod grammar {
                 source: &[u8],
                 last_idx: &mut usize,
             ) -> Box<Expression> {
-                if let Some(cursor) = cursor_opt.as_mut() {
-                    loop {
-                        let n = cursor.node();
-                        if let Some(name) = cursor.field_name() {
-                            if name == "0" {
-                                let node: Option<rust_sitter::tree_sitter::Node> = Some(n);
-                                let out = <Box<Expression> as rust_sitter::Extract<_>>::extract(
-                                    node, source, *last_idx, None,
-                                );
-                                if !cursor.goto_next_sibling() {
-                                    *cursor_opt = None;
-                                };
-                                *last_idx = n.end_byte();
-                                return out;
-                            } else {
-                                let node: Option<rust_sitter::tree_sitter::Node> = None;
-                                return <Box<Expression> as rust_sitter::Extract<_>>::extract(
-                                    node, source, *last_idx, None,
-                                );
-                            }
-                        } else {
-                            *last_idx = n.end_byte();
-                        }
-                        if !cursor.goto_next_sibling() {
-                            let node: Option<rust_sitter::tree_sitter::Node> = None;
-                            return <Box<Expression> as rust_sitter::Extract<_>>::extract(
-                                node, source, *last_idx, None,
-                            );
-                        }
-                    }
-                } else {
-                    let node: Option<rust_sitter::tree_sitter::Node> = None;
-                    return <Box<Expression> as rust_sitter::Extract<_>>::extract(
-                        node, source, *last_idx, None,
-                    );
-                }
+                rust_sitter::__private::extract_field(
+                    cursor_opt,
+                    last_idx,
+                    "0",
+                    move |node, last_idx| {
+                        <Box<Expression> as rust_sitter::Extract<_>>::extract(
+                            node, source, *last_idx, None,
+                        )
+                    },
+                )
             }
             #[allow(non_snake_case)]
             #[allow(clippy::unused_unit)]
@@ -127,40 +72,14 @@ mod grammar {
                 source: &[u8],
                 last_idx: &mut usize,
             ) -> () {
-                if let Some(cursor) = cursor_opt.as_mut() {
-                    loop {
-                        let n = cursor.node();
-                        if let Some(name) = cursor.field_name() {
-                            if name == "1" {
-                                let node: Option<rust_sitter::tree_sitter::Node> = Some(n);
-                                let out = <() as rust_sitter::Extract<_>>::extract(
-                                    node, source, *last_idx, None,
-                                );
-                                if !cursor.goto_next_sibling() {
-                                    *cursor_opt = None;
-                                };
-                                *last_idx = n.end_byte();
-                                return out;
-                            } else {
-                                let node: Option<rust_sitter::tree_sitter::Node> = None;
-                                return <() as rust_sitter::Extract<_>>::extract(
-                                    node, source, *last_idx, None,
-                                );
-                            }
-                        } else {
-                            *last_idx = n.end_byte();
-                        }
-                        if !cursor.goto_next_sibling() {
-                            let node: Option<rust_sitter::tree_sitter::Node> = None;
-                            return <() as rust_sitter::Extract<_>>::extract(
-                                node, source, *last_idx, None,
-                            );
-                        }
-                    }
-                } else {
-                    let node: Option<rust_sitter::tree_sitter::Node> = None;
-                    return <() as rust_sitter::Extract<_>>::extract(node, source, *last_idx, None);
-                }
+                rust_sitter::__private::extract_field(
+                    cursor_opt,
+                    last_idx,
+                    "1",
+                    move |node, last_idx| {
+                        <() as rust_sitter::Extract<_>>::extract(node, source, *last_idx, None)
+                    },
+                )
             }
             #[allow(non_snake_case)]
             #[allow(clippy::unused_unit)]
@@ -169,60 +88,29 @@ mod grammar {
                 source: &[u8],
                 last_idx: &mut usize,
             ) -> Box<Expression> {
-                if let Some(cursor) = cursor_opt.as_mut() {
-                    loop {
-                        let n = cursor.node();
-                        if let Some(name) = cursor.field_name() {
-                            if name == "2" {
-                                let node: Option<rust_sitter::tree_sitter::Node> = Some(n);
-                                let out = <Box<Expression> as rust_sitter::Extract<_>>::extract(
-                                    node, source, *last_idx, None,
-                                );
-                                if !cursor.goto_next_sibling() {
-                                    *cursor_opt = None;
-                                };
-                                *last_idx = n.end_byte();
-                                return out;
-                            } else {
-                                let node: Option<rust_sitter::tree_sitter::Node> = None;
-                                return <Box<Expression> as rust_sitter::Extract<_>>::extract(
-                                    node, source, *last_idx, None,
-                                );
-                            }
-                        } else {
-                            *last_idx = n.end_byte();
-                        }
-                        if !cursor.goto_next_sibling() {
-                            let node: Option<rust_sitter::tree_sitter::Node> = None;
-                            return <Box<Expression> as rust_sitter::Extract<_>>::extract(
-                                node, source, *last_idx, None,
-                            );
-                        }
-                    }
-                } else {
-                    let node: Option<rust_sitter::tree_sitter::Node> = None;
-                    return <Box<Expression> as rust_sitter::Extract<_>>::extract(
-                        node, source, *last_idx, None,
-                    );
-                }
+                rust_sitter::__private::extract_field(
+                    cursor_opt,
+                    last_idx,
+                    "2",
+                    move |node, last_idx| {
+                        <Box<Expression> as rust_sitter::Extract<_>>::extract(
+                            node, source, *last_idx, None,
+                        )
+                    },
+                )
             }
             #[allow(non_snake_case)]
             fn extract_Expression_Sub(
                 node: rust_sitter::tree_sitter::Node,
                 source: &[u8],
             ) -> Expression {
-                let mut last_idx = node.start_byte();
-                let mut parent_cursor = node.walk();
-                let mut cursor = if parent_cursor.goto_first_child() {
-                    Some(parent_cursor)
-                } else {
-                    None
-                };
-                Expression::Sub(
-                    extract_Expression_Sub_0(&mut cursor, source, &mut last_idx),
-                    extract_Expression_Sub_1(&mut cursor, source, &mut last_idx),
-                    extract_Expression_Sub_2(&mut cursor, source, &mut last_idx),
-                )
+                rust_sitter::__private::extract_struct_or_variant(node, move |cursor, last_idx| {
+                    Expression::Sub(
+                        extract_Expression_Sub_0(cursor, source, last_idx),
+                        extract_Expression_Sub_1(cursor, source, last_idx),
+                        extract_Expression_Sub_2(cursor, source, last_idx),
+                    )
+                })
             }
             let mut cursor = node.walk();
             assert!(cursor.goto_first_child());

--- a/macro/src/snapshots/rust_sitter_macro__tests__enum_recursive.snap
+++ b/macro/src/snapshots/rust_sitter_macro__tests__enum_recursive.snap
@@ -24,57 +24,28 @@ mod grammar {
                 source: &[u8],
                 last_idx: &mut usize,
             ) -> i32 {
-                if let Some(cursor) = cursor_opt.as_mut() {
-                    loop {
-                        let n = cursor.node();
-                        if let Some(name) = cursor.field_name() {
-                            if name == "0" {
-                                let node: Option<rust_sitter::tree_sitter::Node> = Some(n);
-                                let out = < rust_sitter :: WithLeaf < i32 > as rust_sitter :: Extract < _ > > :: extract (node , source , * last_idx , Some (& | v | v . parse () . unwrap ())) ;
-                                if !cursor.goto_next_sibling() {
-                                    *cursor_opt = None;
-                                };
-                                *last_idx = n.end_byte();
-                                return out;
-                            } else {
-                                let node: Option<rust_sitter::tree_sitter::Node> = None;
-                                return < rust_sitter :: WithLeaf < i32 > as rust_sitter :: Extract < _ > > :: extract (node , source , * last_idx , Some (& | v | v . parse () . unwrap ())) ;
-                            }
-                        } else {
-                            *last_idx = n.end_byte();
-                        }
-                        if !cursor.goto_next_sibling() {
-                            let node: Option<rust_sitter::tree_sitter::Node> = None;
-                            return < rust_sitter :: WithLeaf < i32 > as rust_sitter :: Extract < _ > > :: extract (node , source , * last_idx , Some (& | v | v . parse () . unwrap ())) ;
-                        }
-                    }
-                } else {
-                    let node: Option<rust_sitter::tree_sitter::Node> = None;
-                    return <rust_sitter::WithLeaf<i32> as rust_sitter::Extract<_>>::extract(
-                        node,
-                        source,
-                        *last_idx,
-                        Some(&|v| v.parse().unwrap()),
-                    );
-                }
+                rust_sitter::__private::extract_field(
+                    cursor_opt,
+                    last_idx,
+                    "0",
+                    move |node, last_idx| {
+                        <rust_sitter::WithLeaf<i32> as rust_sitter::Extract<_>>::extract(
+                            node,
+                            source,
+                            *last_idx,
+                            Some(&|v| v.parse().unwrap()),
+                        )
+                    },
+                )
             }
             #[allow(non_snake_case)]
             fn extract_Expression_Number(
                 node: rust_sitter::tree_sitter::Node,
                 source: &[u8],
             ) -> Expression {
-                let mut last_idx = node.start_byte();
-                let mut parent_cursor = node.walk();
-                let mut cursor = if parent_cursor.goto_first_child() {
-                    Some(parent_cursor)
-                } else {
-                    None
-                };
-                Expression::Number(extract_Expression_Number_0(
-                    &mut cursor,
-                    source,
-                    &mut last_idx,
-                ))
+                rust_sitter::__private::extract_struct_or_variant(node, move |cursor, last_idx| {
+                    Expression::Number(extract_Expression_Number_0(cursor, source, last_idx))
+                })
             }
             #[allow(non_snake_case)]
             #[allow(clippy::unused_unit)]
@@ -83,40 +54,14 @@ mod grammar {
                 source: &[u8],
                 last_idx: &mut usize,
             ) -> () {
-                if let Some(cursor) = cursor_opt.as_mut() {
-                    loop {
-                        let n = cursor.node();
-                        if let Some(name) = cursor.field_name() {
-                            if name == "0" {
-                                let node: Option<rust_sitter::tree_sitter::Node> = Some(n);
-                                let out = <() as rust_sitter::Extract<_>>::extract(
-                                    node, source, *last_idx, None,
-                                );
-                                if !cursor.goto_next_sibling() {
-                                    *cursor_opt = None;
-                                };
-                                *last_idx = n.end_byte();
-                                return out;
-                            } else {
-                                let node: Option<rust_sitter::tree_sitter::Node> = None;
-                                return <() as rust_sitter::Extract<_>>::extract(
-                                    node, source, *last_idx, None,
-                                );
-                            }
-                        } else {
-                            *last_idx = n.end_byte();
-                        }
-                        if !cursor.goto_next_sibling() {
-                            let node: Option<rust_sitter::tree_sitter::Node> = None;
-                            return <() as rust_sitter::Extract<_>>::extract(
-                                node, source, *last_idx, None,
-                            );
-                        }
-                    }
-                } else {
-                    let node: Option<rust_sitter::tree_sitter::Node> = None;
-                    return <() as rust_sitter::Extract<_>>::extract(node, source, *last_idx, None);
-                }
+                rust_sitter::__private::extract_field(
+                    cursor_opt,
+                    last_idx,
+                    "0",
+                    move |node, last_idx| {
+                        <() as rust_sitter::Extract<_>>::extract(node, source, *last_idx, None)
+                    },
+                )
             }
             #[allow(non_snake_case)]
             #[allow(clippy::unused_unit)]
@@ -125,59 +70,28 @@ mod grammar {
                 source: &[u8],
                 last_idx: &mut usize,
             ) -> Box<Expression> {
-                if let Some(cursor) = cursor_opt.as_mut() {
-                    loop {
-                        let n = cursor.node();
-                        if let Some(name) = cursor.field_name() {
-                            if name == "1" {
-                                let node: Option<rust_sitter::tree_sitter::Node> = Some(n);
-                                let out = <Box<Expression> as rust_sitter::Extract<_>>::extract(
-                                    node, source, *last_idx, None,
-                                );
-                                if !cursor.goto_next_sibling() {
-                                    *cursor_opt = None;
-                                };
-                                *last_idx = n.end_byte();
-                                return out;
-                            } else {
-                                let node: Option<rust_sitter::tree_sitter::Node> = None;
-                                return <Box<Expression> as rust_sitter::Extract<_>>::extract(
-                                    node, source, *last_idx, None,
-                                );
-                            }
-                        } else {
-                            *last_idx = n.end_byte();
-                        }
-                        if !cursor.goto_next_sibling() {
-                            let node: Option<rust_sitter::tree_sitter::Node> = None;
-                            return <Box<Expression> as rust_sitter::Extract<_>>::extract(
-                                node, source, *last_idx, None,
-                            );
-                        }
-                    }
-                } else {
-                    let node: Option<rust_sitter::tree_sitter::Node> = None;
-                    return <Box<Expression> as rust_sitter::Extract<_>>::extract(
-                        node, source, *last_idx, None,
-                    );
-                }
+                rust_sitter::__private::extract_field(
+                    cursor_opt,
+                    last_idx,
+                    "1",
+                    move |node, last_idx| {
+                        <Box<Expression> as rust_sitter::Extract<_>>::extract(
+                            node, source, *last_idx, None,
+                        )
+                    },
+                )
             }
             #[allow(non_snake_case)]
             fn extract_Expression_Neg(
                 node: rust_sitter::tree_sitter::Node,
                 source: &[u8],
             ) -> Expression {
-                let mut last_idx = node.start_byte();
-                let mut parent_cursor = node.walk();
-                let mut cursor = if parent_cursor.goto_first_child() {
-                    Some(parent_cursor)
-                } else {
-                    None
-                };
-                Expression::Neg(
-                    extract_Expression_Neg_0(&mut cursor, source, &mut last_idx),
-                    extract_Expression_Neg_1(&mut cursor, source, &mut last_idx),
-                )
+                rust_sitter::__private::extract_struct_or_variant(node, move |cursor, last_idx| {
+                    Expression::Neg(
+                        extract_Expression_Neg_0(cursor, source, last_idx),
+                        extract_Expression_Neg_1(cursor, source, last_idx),
+                    )
+                })
             }
             let mut cursor = node.walk();
             assert!(cursor.goto_first_child());

--- a/macro/src/snapshots/rust_sitter_macro__tests__enum_recursive.snap
+++ b/macro/src/snapshots/rust_sitter_macro__tests__enum_recursive.snap
@@ -1,105 +1,64 @@
 ---
 source: macro/src/lib.rs
-expression: "rustfmt_code(&expand_grammar(parse_quote! {\n                            #[rust_sitter :: grammar(\"test\")] mod grammar\n                            {\n                                #[rust_sitter :: language] pub enum Expression\n                                {\n                                    Number(#[rust_sitter ::\n                                    leaf(pattern = r\"\\d+\", transform = | v |\n                                    v.parse().unwrap())] i32),\n                                    Neg(#[rust_sitter :: leaf(text = \"-\")] (), Box < Expression\n                                    >),\n                                }\n                            }\n                        }).to_token_stream().to_string())"
+expression: "rustfmt_code(&expand_grammar(parse_quote! {\n                                #[rust_sitter :: grammar(\"test\")] mod grammar\n                                {\n                                    #[rust_sitter :: language] pub enum Expression\n                                    {\n                                        Number(#[rust_sitter ::\n                                        leaf(pattern = r\"\\d+\", transform = | v |\n                                        v.parse().unwrap())] i32),\n                                        Neg(#[rust_sitter :: leaf(text = \"-\")] (), Box < Expression\n                                        >),\n                                    }\n                                }\n                            })?.to_token_stream().to_string())"
 ---
 mod grammar {
     pub enum Expression {
         Number(i32),
         Neg((), Box<Expression>),
     }
-    impl rust_sitter::Extract<Expression> for Expression {
+    impl ::rust_sitter::Extract<Expression> for Expression {
         type LeafFn = ();
         #[allow(non_snake_case)]
         fn extract(
-            node: Option<rust_sitter::tree_sitter::Node>,
+            node: Option<::rust_sitter::tree_sitter::Node>,
             source: &[u8],
             _last_idx: usize,
             _leaf_fn: Option<&Self::LeafFn>,
         ) -> Self {
             let node = node.unwrap();
-            #[allow(non_snake_case)]
-            #[allow(clippy::unused_unit)]
-            fn extract_Expression_Number_0(
-                cursor_opt: &mut Option<rust_sitter::tree_sitter::TreeCursor>,
-                source: &[u8],
-                last_idx: &mut usize,
-            ) -> i32 {
-                rust_sitter::__private::extract_field(
-                    cursor_opt,
-                    last_idx,
-                    "0",
-                    move |node, last_idx| {
-                        <rust_sitter::WithLeaf<i32> as rust_sitter::Extract<_>>::extract(
-                            node,
-                            source,
-                            *last_idx,
-                            Some(&|v| v.parse().unwrap()),
-                        )
-                    },
-                )
-            }
-            #[allow(non_snake_case)]
-            fn extract_Expression_Number(
-                node: rust_sitter::tree_sitter::Node,
-                source: &[u8],
-            ) -> Expression {
-                rust_sitter::__private::extract_struct_or_variant(node, move |cursor, last_idx| {
-                    Expression::Number(extract_Expression_Number_0(cursor, source, last_idx))
-                })
-            }
-            #[allow(non_snake_case)]
-            #[allow(clippy::unused_unit)]
-            fn extract_Expression_Neg_0(
-                cursor_opt: &mut Option<rust_sitter::tree_sitter::TreeCursor>,
-                source: &[u8],
-                last_idx: &mut usize,
-            ) -> () {
-                rust_sitter::__private::extract_field(
-                    cursor_opt,
-                    last_idx,
-                    "0",
-                    move |node, last_idx| {
-                        <() as rust_sitter::Extract<_>>::extract(node, source, *last_idx, None)
-                    },
-                )
-            }
-            #[allow(non_snake_case)]
-            #[allow(clippy::unused_unit)]
-            fn extract_Expression_Neg_1(
-                cursor_opt: &mut Option<rust_sitter::tree_sitter::TreeCursor>,
-                source: &[u8],
-                last_idx: &mut usize,
-            ) -> Box<Expression> {
-                rust_sitter::__private::extract_field(
-                    cursor_opt,
-                    last_idx,
-                    "1",
-                    move |node, last_idx| {
-                        <Box<Expression> as rust_sitter::Extract<_>>::extract(
-                            node, source, *last_idx, None,
-                        )
-                    },
-                )
-            }
-            #[allow(non_snake_case)]
-            fn extract_Expression_Neg(
-                node: rust_sitter::tree_sitter::Node,
-                source: &[u8],
-            ) -> Expression {
-                rust_sitter::__private::extract_struct_or_variant(node, move |cursor, last_idx| {
-                    Expression::Neg(
-                        extract_Expression_Neg_0(cursor, source, last_idx),
-                        extract_Expression_Neg_1(cursor, source, last_idx),
-                    )
-                })
-            }
             let mut cursor = node.walk();
-            assert!(cursor.goto_first_child());
+            assert!(
+                cursor.goto_first_child(),
+                "Could not find a child corresponding to any enum branch"
+            );
             loop {
-                let n = cursor.node();
-                match n.kind() {
-                    "Expression_Number" => return extract_Expression_Number(n, source),
-                    "Expression_Neg" => return extract_Expression_Neg(n, source),
+                let node = cursor.node();
+                match node.kind() {
+                    "Expression_Number" => {
+                        return ::rust_sitter::__private::extract_struct_or_variant(
+                            node,
+                            move |cursor, last_idx| {
+                                Expression::Number({
+                                    ::rust_sitter::__private::extract_field::<
+                                        rust_sitter::WithLeaf<i32>,
+                                        _,
+                                    >(
+                                        cursor, source, last_idx, "0", Some(&|v| v.parse().unwrap())
+                                    )
+                                })
+                            },
+                        )
+                    }
+                    "Expression_Neg" => {
+                        return ::rust_sitter::__private::extract_struct_or_variant(
+                            node,
+                            move |cursor, last_idx| {
+                                Expression::Neg(
+                                    {
+                                        ::rust_sitter::__private::extract_field::<(), _>(
+                                            cursor, source, last_idx, "0", None,
+                                        )
+                                    },
+                                    {
+                                        ::rust_sitter::__private::extract_field::<Box<Expression>, _>(
+                                            cursor, source, last_idx, "1", None,
+                                        )
+                                    },
+                                )
+                            },
+                        )
+                    }
                     _ => {
                         if !cursor.goto_next_sibling() {
                             panic!("Could not find a child corresponding to any enum branch")
@@ -110,31 +69,18 @@ mod grammar {
         }
     }
     extern "C" {
-        fn tree_sitter_test() -> rust_sitter::tree_sitter::Language;
+        fn tree_sitter_test() -> ::rust_sitter::tree_sitter::Language;
     }
-    pub fn language() -> rust_sitter::tree_sitter::Language {
+    pub fn language() -> ::rust_sitter::tree_sitter::Language {
         unsafe { tree_sitter_test() }
     }
+    #[doc = r" Parse an input string according to the grammar. Returns either any parsing errors that happened, or a"]
+    #[doc = "[`Expression`]"]
+    #[doc = r" instance containing the parsed structured data."]
     pub fn parse(
         input: &str,
-    ) -> core::result::Result<Expression, Vec<rust_sitter::errors::ParseError>> {
-        let mut parser = rust_sitter::tree_sitter::Parser::new();
-        parser.set_language(language()).unwrap();
-        let tree = parser.parse(input, None).unwrap();
-        let root_node = tree.root_node();
-        if root_node.has_error() {
-            let mut errors = vec![];
-            rust_sitter::errors::collect_parsing_errors(&root_node, input.as_bytes(), &mut errors);
-            Err(errors)
-        } else {
-            use rust_sitter::Extract;
-            Ok(<Expression as rust_sitter::Extract<_>>::extract(
-                Some(root_node),
-                input.as_bytes(),
-                0,
-                None,
-            ))
-        }
+    ) -> core::result::Result<Expression, Vec<::rust_sitter::errors::ParseError>> {
+        ::rust_sitter::__private::parse::<Expression>(input, language)
     }
 }
 

--- a/macro/src/snapshots/rust_sitter_macro__tests__enum_transformed_fields.snap
+++ b/macro/src/snapshots/rust_sitter_macro__tests__enum_transformed_fields.snap
@@ -23,57 +23,28 @@ mod grammar {
                 source: &[u8],
                 last_idx: &mut usize,
             ) -> i32 {
-                if let Some(cursor) = cursor_opt.as_mut() {
-                    loop {
-                        let n = cursor.node();
-                        if let Some(name) = cursor.field_name() {
-                            if name == "0" {
-                                let node: Option<rust_sitter::tree_sitter::Node> = Some(n);
-                                let out = < rust_sitter :: WithLeaf < i32 > as rust_sitter :: Extract < _ > > :: extract (node , source , * last_idx , Some (& | v | v . parse :: < i32 > () . unwrap ())) ;
-                                if !cursor.goto_next_sibling() {
-                                    *cursor_opt = None;
-                                };
-                                *last_idx = n.end_byte();
-                                return out;
-                            } else {
-                                let node: Option<rust_sitter::tree_sitter::Node> = None;
-                                return < rust_sitter :: WithLeaf < i32 > as rust_sitter :: Extract < _ > > :: extract (node , source , * last_idx , Some (& | v | v . parse :: < i32 > () . unwrap ())) ;
-                            }
-                        } else {
-                            *last_idx = n.end_byte();
-                        }
-                        if !cursor.goto_next_sibling() {
-                            let node: Option<rust_sitter::tree_sitter::Node> = None;
-                            return < rust_sitter :: WithLeaf < i32 > as rust_sitter :: Extract < _ > > :: extract (node , source , * last_idx , Some (& | v | v . parse :: < i32 > () . unwrap ())) ;
-                        }
-                    }
-                } else {
-                    let node: Option<rust_sitter::tree_sitter::Node> = None;
-                    return <rust_sitter::WithLeaf<i32> as rust_sitter::Extract<_>>::extract(
-                        node,
-                        source,
-                        *last_idx,
-                        Some(&|v| v.parse::<i32>().unwrap()),
-                    );
-                }
+                rust_sitter::__private::extract_field(
+                    cursor_opt,
+                    last_idx,
+                    "0",
+                    move |node, last_idx| {
+                        <rust_sitter::WithLeaf<i32> as rust_sitter::Extract<_>>::extract(
+                            node,
+                            source,
+                            *last_idx,
+                            Some(&|v| v.parse::<i32>().unwrap()),
+                        )
+                    },
+                )
             }
             #[allow(non_snake_case)]
             fn extract_Expression_Number(
                 node: rust_sitter::tree_sitter::Node,
                 source: &[u8],
             ) -> Expression {
-                let mut last_idx = node.start_byte();
-                let mut parent_cursor = node.walk();
-                let mut cursor = if parent_cursor.goto_first_child() {
-                    Some(parent_cursor)
-                } else {
-                    None
-                };
-                Expression::Number(extract_Expression_Number_0(
-                    &mut cursor,
-                    source,
-                    &mut last_idx,
-                ))
+                rust_sitter::__private::extract_struct_or_variant(node, move |cursor, last_idx| {
+                    Expression::Number(extract_Expression_Number_0(cursor, source, last_idx))
+                })
             }
             let mut cursor = node.walk();
             assert!(cursor.goto_first_child());

--- a/macro/src/snapshots/rust_sitter_macro__tests__enum_transformed_fields.snap
+++ b/macro/src/snapshots/rust_sitter_macro__tests__enum_transformed_fields.snap
@@ -1,57 +1,48 @@
 ---
 source: macro/src/lib.rs
-expression: "rustfmt_code(&expand_grammar(parse_quote! {\n                            #[rust_sitter :: grammar(\"test\")] mod grammar\n                            {\n                                #[rust_sitter :: language] pub enum Expression\n                                {\n                                    Number(#[rust_sitter ::\n                                    leaf(pattern = r\"\\d+\", transform = | v | v.parse :: < i32 >\n                                    ().unwrap())] i32),\n                                }\n                            }\n                        }).to_token_stream().to_string())"
+expression: "rustfmt_code(&expand_grammar(parse_quote! {\n                                #[rust_sitter :: grammar(\"test\")] mod grammar\n                                {\n                                    #[rust_sitter :: language] pub enum Expression\n                                    {\n                                        Number(#[rust_sitter ::\n                                        leaf(pattern = r\"\\d+\", transform = | v | v.parse :: < i32 >\n                                        ().unwrap())] i32),\n                                    }\n                                }\n                            })?.to_token_stream().to_string())"
 ---
 mod grammar {
     pub enum Expression {
         Number(i32),
     }
-    impl rust_sitter::Extract<Expression> for Expression {
+    impl ::rust_sitter::Extract<Expression> for Expression {
         type LeafFn = ();
         #[allow(non_snake_case)]
         fn extract(
-            node: Option<rust_sitter::tree_sitter::Node>,
+            node: Option<::rust_sitter::tree_sitter::Node>,
             source: &[u8],
             _last_idx: usize,
             _leaf_fn: Option<&Self::LeafFn>,
         ) -> Self {
             let node = node.unwrap();
-            #[allow(non_snake_case)]
-            #[allow(clippy::unused_unit)]
-            fn extract_Expression_Number_0(
-                cursor_opt: &mut Option<rust_sitter::tree_sitter::TreeCursor>,
-                source: &[u8],
-                last_idx: &mut usize,
-            ) -> i32 {
-                rust_sitter::__private::extract_field(
-                    cursor_opt,
-                    last_idx,
-                    "0",
-                    move |node, last_idx| {
-                        <rust_sitter::WithLeaf<i32> as rust_sitter::Extract<_>>::extract(
-                            node,
-                            source,
-                            *last_idx,
-                            Some(&|v| v.parse::<i32>().unwrap()),
-                        )
-                    },
-                )
-            }
-            #[allow(non_snake_case)]
-            fn extract_Expression_Number(
-                node: rust_sitter::tree_sitter::Node,
-                source: &[u8],
-            ) -> Expression {
-                rust_sitter::__private::extract_struct_or_variant(node, move |cursor, last_idx| {
-                    Expression::Number(extract_Expression_Number_0(cursor, source, last_idx))
-                })
-            }
             let mut cursor = node.walk();
-            assert!(cursor.goto_first_child());
+            assert!(
+                cursor.goto_first_child(),
+                "Could not find a child corresponding to any enum branch"
+            );
             loop {
-                let n = cursor.node();
-                match n.kind() {
-                    "Expression_Number" => return extract_Expression_Number(n, source),
+                let node = cursor.node();
+                match node.kind() {
+                    "Expression_Number" => {
+                        return ::rust_sitter::__private::extract_struct_or_variant(
+                            node,
+                            move |cursor, last_idx| {
+                                Expression::Number({
+                                    ::rust_sitter::__private::extract_field::<
+                                        rust_sitter::WithLeaf<i32>,
+                                        _,
+                                    >(
+                                        cursor,
+                                        source,
+                                        last_idx,
+                                        "0",
+                                        Some(&|v| v.parse::<i32>().unwrap()),
+                                    )
+                                })
+                            },
+                        )
+                    }
                     _ => {
                         if !cursor.goto_next_sibling() {
                             panic!("Could not find a child corresponding to any enum branch")
@@ -62,31 +53,18 @@ mod grammar {
         }
     }
     extern "C" {
-        fn tree_sitter_test() -> rust_sitter::tree_sitter::Language;
+        fn tree_sitter_test() -> ::rust_sitter::tree_sitter::Language;
     }
-    pub fn language() -> rust_sitter::tree_sitter::Language {
+    pub fn language() -> ::rust_sitter::tree_sitter::Language {
         unsafe { tree_sitter_test() }
     }
+    #[doc = r" Parse an input string according to the grammar. Returns either any parsing errors that happened, or a"]
+    #[doc = "[`Expression`]"]
+    #[doc = r" instance containing the parsed structured data."]
     pub fn parse(
         input: &str,
-    ) -> core::result::Result<Expression, Vec<rust_sitter::errors::ParseError>> {
-        let mut parser = rust_sitter::tree_sitter::Parser::new();
-        parser.set_language(language()).unwrap();
-        let tree = parser.parse(input, None).unwrap();
-        let root_node = tree.root_node();
-        if root_node.has_error() {
-            let mut errors = vec![];
-            rust_sitter::errors::collect_parsing_errors(&root_node, input.as_bytes(), &mut errors);
-            Err(errors)
-        } else {
-            use rust_sitter::Extract;
-            Ok(<Expression as rust_sitter::Extract<_>>::extract(
-                Some(root_node),
-                input.as_bytes(),
-                0,
-                None,
-            ))
-        }
+    ) -> core::result::Result<Expression, Vec<::rust_sitter::errors::ParseError>> {
+        ::rust_sitter::__private::parse::<Expression>(input, language)
     }
 }
 

--- a/macro/src/snapshots/rust_sitter_macro__tests__enum_with_named_field.snap
+++ b/macro/src/snapshots/rust_sitter_macro__tests__enum_with_named_field.snap
@@ -1,99 +1,62 @@
 ---
 source: macro/src/lib.rs
-expression: "rustfmt_code(&expand_grammar(parse_quote! {\n                            #[rust_sitter :: grammar(\"test\")] mod grammar\n                            {\n                                #[rust_sitter :: language] pub enum Expr\n                                {\n                                    Number(#[rust_sitter ::\n                                    leaf(pattern = r\"\\d+\", transform = | v |\n                                    v.parse().unwrap())] u32), Neg\n                                    {\n                                        #[rust_sitter :: leaf(text = \"!\")] _bang : (), value : Box <\n                                        Expr >,\n                                    }\n                                }\n                            }\n                        }).to_token_stream().to_string())"
+expression: "rustfmt_code(&expand_grammar(parse_quote! {\n                                #[rust_sitter :: grammar(\"test\")] mod grammar\n                                {\n                                    #[rust_sitter :: language] pub enum Expr\n                                    {\n                                        Number(#[rust_sitter ::\n                                        leaf(pattern = r\"\\d+\", transform = | v |\n                                        v.parse().unwrap())] u32), Neg\n                                        {\n                                            #[rust_sitter :: leaf(text = \"!\")] _bang : (), value : Box <\n                                            Expr >,\n                                        }\n                                    }\n                                }\n                            })?.to_token_stream().to_string())"
 ---
 mod grammar {
     pub enum Expr {
         Number(u32),
         Neg { _bang: (), value: Box<Expr> },
     }
-    impl rust_sitter::Extract<Expr> for Expr {
+    impl ::rust_sitter::Extract<Expr> for Expr {
         type LeafFn = ();
         #[allow(non_snake_case)]
         fn extract(
-            node: Option<rust_sitter::tree_sitter::Node>,
+            node: Option<::rust_sitter::tree_sitter::Node>,
             source: &[u8],
             _last_idx: usize,
             _leaf_fn: Option<&Self::LeafFn>,
         ) -> Self {
             let node = node.unwrap();
-            #[allow(non_snake_case)]
-            #[allow(clippy::unused_unit)]
-            fn extract_Expr_Number_0(
-                cursor_opt: &mut Option<rust_sitter::tree_sitter::TreeCursor>,
-                source: &[u8],
-                last_idx: &mut usize,
-            ) -> u32 {
-                rust_sitter::__private::extract_field(
-                    cursor_opt,
-                    last_idx,
-                    "0",
-                    move |node, last_idx| {
-                        <rust_sitter::WithLeaf<u32> as rust_sitter::Extract<_>>::extract(
-                            node,
-                            source,
-                            *last_idx,
-                            Some(&|v| v.parse().unwrap()),
-                        )
-                    },
-                )
-            }
-            #[allow(non_snake_case)]
-            fn extract_Expr_Number(node: rust_sitter::tree_sitter::Node, source: &[u8]) -> Expr {
-                rust_sitter::__private::extract_struct_or_variant(node, move |cursor, last_idx| {
-                    Expr::Number(extract_Expr_Number_0(cursor, source, last_idx))
-                })
-            }
-            #[allow(non_snake_case)]
-            #[allow(clippy::unused_unit)]
-            fn extract_Expr_Neg__bang(
-                cursor_opt: &mut Option<rust_sitter::tree_sitter::TreeCursor>,
-                source: &[u8],
-                last_idx: &mut usize,
-            ) -> () {
-                rust_sitter::__private::extract_field(
-                    cursor_opt,
-                    last_idx,
-                    "_bang",
-                    move |node, last_idx| {
-                        <() as rust_sitter::Extract<_>>::extract(node, source, *last_idx, None)
-                    },
-                )
-            }
-            #[allow(non_snake_case)]
-            #[allow(clippy::unused_unit)]
-            fn extract_Expr_Neg_value(
-                cursor_opt: &mut Option<rust_sitter::tree_sitter::TreeCursor>,
-                source: &[u8],
-                last_idx: &mut usize,
-            ) -> Box<Expr> {
-                rust_sitter::__private::extract_field(
-                    cursor_opt,
-                    last_idx,
-                    "value",
-                    move |node, last_idx| {
-                        <Box<Expr> as rust_sitter::Extract<_>>::extract(
-                            node, source, *last_idx, None,
-                        )
-                    },
-                )
-            }
-            #[allow(non_snake_case)]
-            fn extract_Expr_Neg(node: rust_sitter::tree_sitter::Node, source: &[u8]) -> Expr {
-                rust_sitter::__private::extract_struct_or_variant(node, move |cursor, last_idx| {
-                    Expr::Neg {
-                        _bang: extract_Expr_Neg__bang(cursor, source, last_idx),
-                        value: extract_Expr_Neg_value(cursor, source, last_idx),
-                    }
-                })
-            }
             let mut cursor = node.walk();
-            assert!(cursor.goto_first_child());
+            assert!(
+                cursor.goto_first_child(),
+                "Could not find a child corresponding to any enum branch"
+            );
             loop {
-                let n = cursor.node();
-                match n.kind() {
-                    "Expr_Number" => return extract_Expr_Number(n, source),
-                    "Expr_Neg" => return extract_Expr_Neg(n, source),
+                let node = cursor.node();
+                match node.kind() {
+                    "Expr_Number" => {
+                        return ::rust_sitter::__private::extract_struct_or_variant(
+                            node,
+                            move |cursor, last_idx| {
+                                Expr::Number({
+                                    ::rust_sitter::__private::extract_field::<
+                                        rust_sitter::WithLeaf<u32>,
+                                        _,
+                                    >(
+                                        cursor, source, last_idx, "0", Some(&|v| v.parse().unwrap())
+                                    )
+                                })
+                            },
+                        )
+                    }
+                    "Expr_Neg" => {
+                        return ::rust_sitter::__private::extract_struct_or_variant(
+                            node,
+                            move |cursor, last_idx| Expr::Neg {
+                                _bang: {
+                                    ::rust_sitter::__private::extract_field::<(), _>(
+                                        cursor, source, last_idx, "_bang", None,
+                                    )
+                                },
+                                value: {
+                                    ::rust_sitter::__private::extract_field::<Box<Expr>, _>(
+                                        cursor, source, last_idx, "value", None,
+                                    )
+                                },
+                            },
+                        )
+                    }
                     _ => {
                         if !cursor.goto_next_sibling() {
                             panic!("Could not find a child corresponding to any enum branch")
@@ -104,29 +67,18 @@ mod grammar {
         }
     }
     extern "C" {
-        fn tree_sitter_test() -> rust_sitter::tree_sitter::Language;
+        fn tree_sitter_test() -> ::rust_sitter::tree_sitter::Language;
     }
-    pub fn language() -> rust_sitter::tree_sitter::Language {
+    pub fn language() -> ::rust_sitter::tree_sitter::Language {
         unsafe { tree_sitter_test() }
     }
-    pub fn parse(input: &str) -> core::result::Result<Expr, Vec<rust_sitter::errors::ParseError>> {
-        let mut parser = rust_sitter::tree_sitter::Parser::new();
-        parser.set_language(language()).unwrap();
-        let tree = parser.parse(input, None).unwrap();
-        let root_node = tree.root_node();
-        if root_node.has_error() {
-            let mut errors = vec![];
-            rust_sitter::errors::collect_parsing_errors(&root_node, input.as_bytes(), &mut errors);
-            Err(errors)
-        } else {
-            use rust_sitter::Extract;
-            Ok(<Expr as rust_sitter::Extract<_>>::extract(
-                Some(root_node),
-                input.as_bytes(),
-                0,
-                None,
-            ))
-        }
+    #[doc = r" Parse an input string according to the grammar. Returns either any parsing errors that happened, or a"]
+    #[doc = "[`Expr`]"]
+    #[doc = r" instance containing the parsed structured data."]
+    pub fn parse(
+        input: &str,
+    ) -> core::result::Result<Expr, Vec<::rust_sitter::errors::ParseError>> {
+        ::rust_sitter::__private::parse::<Expr>(input, language)
     }
 }
 

--- a/macro/src/snapshots/rust_sitter_macro__tests__enum_with_named_field.snap
+++ b/macro/src/snapshots/rust_sitter_macro__tests__enum_with_named_field.snap
@@ -24,50 +24,25 @@ mod grammar {
                 source: &[u8],
                 last_idx: &mut usize,
             ) -> u32 {
-                if let Some(cursor) = cursor_opt.as_mut() {
-                    loop {
-                        let n = cursor.node();
-                        if let Some(name) = cursor.field_name() {
-                            if name == "0" {
-                                let node: Option<rust_sitter::tree_sitter::Node> = Some(n);
-                                let out = < rust_sitter :: WithLeaf < u32 > as rust_sitter :: Extract < _ > > :: extract (node , source , * last_idx , Some (& | v | v . parse () . unwrap ())) ;
-                                if !cursor.goto_next_sibling() {
-                                    *cursor_opt = None;
-                                };
-                                *last_idx = n.end_byte();
-                                return out;
-                            } else {
-                                let node: Option<rust_sitter::tree_sitter::Node> = None;
-                                return < rust_sitter :: WithLeaf < u32 > as rust_sitter :: Extract < _ > > :: extract (node , source , * last_idx , Some (& | v | v . parse () . unwrap ())) ;
-                            }
-                        } else {
-                            *last_idx = n.end_byte();
-                        }
-                        if !cursor.goto_next_sibling() {
-                            let node: Option<rust_sitter::tree_sitter::Node> = None;
-                            return < rust_sitter :: WithLeaf < u32 > as rust_sitter :: Extract < _ > > :: extract (node , source , * last_idx , Some (& | v | v . parse () . unwrap ())) ;
-                        }
-                    }
-                } else {
-                    let node: Option<rust_sitter::tree_sitter::Node> = None;
-                    return <rust_sitter::WithLeaf<u32> as rust_sitter::Extract<_>>::extract(
-                        node,
-                        source,
-                        *last_idx,
-                        Some(&|v| v.parse().unwrap()),
-                    );
-                }
+                rust_sitter::__private::extract_field(
+                    cursor_opt,
+                    last_idx,
+                    "0",
+                    move |node, last_idx| {
+                        <rust_sitter::WithLeaf<u32> as rust_sitter::Extract<_>>::extract(
+                            node,
+                            source,
+                            *last_idx,
+                            Some(&|v| v.parse().unwrap()),
+                        )
+                    },
+                )
             }
             #[allow(non_snake_case)]
             fn extract_Expr_Number(node: rust_sitter::tree_sitter::Node, source: &[u8]) -> Expr {
-                let mut last_idx = node.start_byte();
-                let mut parent_cursor = node.walk();
-                let mut cursor = if parent_cursor.goto_first_child() {
-                    Some(parent_cursor)
-                } else {
-                    None
-                };
-                Expr::Number(extract_Expr_Number_0(&mut cursor, source, &mut last_idx))
+                rust_sitter::__private::extract_struct_or_variant(node, move |cursor, last_idx| {
+                    Expr::Number(extract_Expr_Number_0(cursor, source, last_idx))
+                })
             }
             #[allow(non_snake_case)]
             #[allow(clippy::unused_unit)]
@@ -76,40 +51,14 @@ mod grammar {
                 source: &[u8],
                 last_idx: &mut usize,
             ) -> () {
-                if let Some(cursor) = cursor_opt.as_mut() {
-                    loop {
-                        let n = cursor.node();
-                        if let Some(name) = cursor.field_name() {
-                            if name == "_bang" {
-                                let node: Option<rust_sitter::tree_sitter::Node> = Some(n);
-                                let out = <() as rust_sitter::Extract<_>>::extract(
-                                    node, source, *last_idx, None,
-                                );
-                                if !cursor.goto_next_sibling() {
-                                    *cursor_opt = None;
-                                };
-                                *last_idx = n.end_byte();
-                                return out;
-                            } else {
-                                let node: Option<rust_sitter::tree_sitter::Node> = None;
-                                return <() as rust_sitter::Extract<_>>::extract(
-                                    node, source, *last_idx, None,
-                                );
-                            }
-                        } else {
-                            *last_idx = n.end_byte();
-                        }
-                        if !cursor.goto_next_sibling() {
-                            let node: Option<rust_sitter::tree_sitter::Node> = None;
-                            return <() as rust_sitter::Extract<_>>::extract(
-                                node, source, *last_idx, None,
-                            );
-                        }
-                    }
-                } else {
-                    let node: Option<rust_sitter::tree_sitter::Node> = None;
-                    return <() as rust_sitter::Extract<_>>::extract(node, source, *last_idx, None);
-                }
+                rust_sitter::__private::extract_field(
+                    cursor_opt,
+                    last_idx,
+                    "_bang",
+                    move |node, last_idx| {
+                        <() as rust_sitter::Extract<_>>::extract(node, source, *last_idx, None)
+                    },
+                )
             }
             #[allow(non_snake_case)]
             #[allow(clippy::unused_unit)]
@@ -118,56 +67,25 @@ mod grammar {
                 source: &[u8],
                 last_idx: &mut usize,
             ) -> Box<Expr> {
-                if let Some(cursor) = cursor_opt.as_mut() {
-                    loop {
-                        let n = cursor.node();
-                        if let Some(name) = cursor.field_name() {
-                            if name == "value" {
-                                let node: Option<rust_sitter::tree_sitter::Node> = Some(n);
-                                let out = <Box<Expr> as rust_sitter::Extract<_>>::extract(
-                                    node, source, *last_idx, None,
-                                );
-                                if !cursor.goto_next_sibling() {
-                                    *cursor_opt = None;
-                                };
-                                *last_idx = n.end_byte();
-                                return out;
-                            } else {
-                                let node: Option<rust_sitter::tree_sitter::Node> = None;
-                                return <Box<Expr> as rust_sitter::Extract<_>>::extract(
-                                    node, source, *last_idx, None,
-                                );
-                            }
-                        } else {
-                            *last_idx = n.end_byte();
-                        }
-                        if !cursor.goto_next_sibling() {
-                            let node: Option<rust_sitter::tree_sitter::Node> = None;
-                            return <Box<Expr> as rust_sitter::Extract<_>>::extract(
-                                node, source, *last_idx, None,
-                            );
-                        }
-                    }
-                } else {
-                    let node: Option<rust_sitter::tree_sitter::Node> = None;
-                    return <Box<Expr> as rust_sitter::Extract<_>>::extract(
-                        node, source, *last_idx, None,
-                    );
-                }
+                rust_sitter::__private::extract_field(
+                    cursor_opt,
+                    last_idx,
+                    "value",
+                    move |node, last_idx| {
+                        <Box<Expr> as rust_sitter::Extract<_>>::extract(
+                            node, source, *last_idx, None,
+                        )
+                    },
+                )
             }
             #[allow(non_snake_case)]
             fn extract_Expr_Neg(node: rust_sitter::tree_sitter::Node, source: &[u8]) -> Expr {
-                let mut last_idx = node.start_byte();
-                let mut parent_cursor = node.walk();
-                let mut cursor = if parent_cursor.goto_first_child() {
-                    Some(parent_cursor)
-                } else {
-                    None
-                };
-                Expr::Neg {
-                    _bang: extract_Expr_Neg__bang(&mut cursor, source, &mut last_idx),
-                    value: extract_Expr_Neg_value(&mut cursor, source, &mut last_idx),
-                }
+                rust_sitter::__private::extract_struct_or_variant(node, move |cursor, last_idx| {
+                    Expr::Neg {
+                        _bang: extract_Expr_Neg__bang(cursor, source, last_idx),
+                        value: extract_Expr_Neg_value(cursor, source, last_idx),
+                    }
+                })
             }
             let mut cursor = node.walk();
             assert!(cursor.goto_first_child());

--- a/macro/src/snapshots/rust_sitter_macro__tests__enum_with_unamed_vector.snap
+++ b/macro/src/snapshots/rust_sitter_macro__tests__enum_with_unamed_vector.snap
@@ -1,96 +1,69 @@
 ---
 source: macro/src/lib.rs
-expression: "rustfmt_code(&expand_grammar(parse_quote! {\n                            #[rust_sitter :: grammar(\"test\")] mod grammar\n                            {\n                                pub struct Number\n                                {\n                                    #[rust_sitter ::\n                                    leaf(pattern = r\"\\d+\", transform = | v |\n                                    v.parse().unwrap())] value : u32\n                                } #[rust_sitter :: language] pub enum Expr\n                                {\n                                    Numbers(#[rust_sitter :: repeat(non_empty = true)] Vec <\n                                    Number >)\n                                }\n                            }\n                        }).to_token_stream().to_string())"
+expression: "rustfmt_code(&expand_grammar(parse_quote! {\n                                #[rust_sitter :: grammar(\"test\")] mod grammar\n                                {\n                                    pub struct Number\n                                    {\n                                        #[rust_sitter ::\n                                        leaf(pattern = r\"\\d+\", transform = | v |\n                                        v.parse().unwrap())] value : u32\n                                    } #[rust_sitter :: language] pub enum Expr\n                                    {\n                                        Numbers(#[rust_sitter :: repeat(non_empty = true)] Vec <\n                                        Number >)\n                                    }\n                                }\n                            })?.to_token_stream().to_string())"
 ---
 mod grammar {
     pub struct Number {
         value: u32,
     }
-    impl rust_sitter::Extract<Number> for Number {
+    impl ::rust_sitter::Extract<Number> for Number {
         type LeafFn = ();
         #[allow(non_snake_case)]
         fn extract(
-            node: Option<rust_sitter::tree_sitter::Node>,
+            node: Option<::rust_sitter::tree_sitter::Node>,
             source: &[u8],
             last_idx: usize,
             _leaf_fn: Option<&Self::LeafFn>,
         ) -> Self {
             let node = node.unwrap();
-            #[allow(non_snake_case)]
-            #[allow(clippy::unused_unit)]
-            fn extract_Number_value(
-                cursor_opt: &mut Option<rust_sitter::tree_sitter::TreeCursor>,
-                source: &[u8],
-                last_idx: &mut usize,
-            ) -> u32 {
-                rust_sitter::__private::extract_field(
-                    cursor_opt,
-                    last_idx,
-                    "value",
-                    move |node, last_idx| {
-                        <rust_sitter::WithLeaf<u32> as rust_sitter::Extract<_>>::extract(
-                            node,
+            ::rust_sitter::__private::extract_struct_or_variant(node, move |cursor, last_idx| {
+                Number {
+                    value: {
+                        ::rust_sitter::__private::extract_field::<rust_sitter::WithLeaf<u32>, _>(
+                            cursor,
                             source,
-                            *last_idx,
+                            last_idx,
+                            "value",
                             Some(&|v| v.parse().unwrap()),
                         )
                     },
-                )
-            }
-            #[allow(non_snake_case)]
-            fn extract_Number(node: rust_sitter::tree_sitter::Node, source: &[u8]) -> Number {
-                rust_sitter::__private::extract_struct_or_variant(node, move |cursor, last_idx| {
-                    Number {
-                        value: extract_Number_value(cursor, source, last_idx),
-                    }
-                })
-            }
-            extract_Number(node, source)
+                }
+            })
         }
     }
     pub enum Expr {
         Numbers(Vec<Number>),
     }
-    impl rust_sitter::Extract<Expr> for Expr {
+    impl ::rust_sitter::Extract<Expr> for Expr {
         type LeafFn = ();
         #[allow(non_snake_case)]
         fn extract(
-            node: Option<rust_sitter::tree_sitter::Node>,
+            node: Option<::rust_sitter::tree_sitter::Node>,
             source: &[u8],
             _last_idx: usize,
             _leaf_fn: Option<&Self::LeafFn>,
         ) -> Self {
             let node = node.unwrap();
-            #[allow(non_snake_case)]
-            #[allow(clippy::unused_unit)]
-            fn extract_Expr_Numbers_0(
-                cursor_opt: &mut Option<rust_sitter::tree_sitter::TreeCursor>,
-                source: &[u8],
-                last_idx: &mut usize,
-            ) -> Vec<Number> {
-                rust_sitter::__private::extract_field(
-                    cursor_opt,
-                    last_idx,
-                    "0",
-                    move |node, last_idx| {
-                        <Vec<Number> as rust_sitter::Extract<_>>::extract(
-                            node, source, *last_idx, None,
-                        )
-                    },
-                )
-            }
-            #[allow(non_snake_case)]
-            fn extract_Expr_Numbers(node: rust_sitter::tree_sitter::Node, source: &[u8]) -> Expr {
-                rust_sitter::__private::extract_struct_or_variant(node, move |cursor, last_idx| {
-                    Expr::Numbers(extract_Expr_Numbers_0(cursor, source, last_idx))
-                })
-            }
             let mut cursor = node.walk();
-            assert!(cursor.goto_first_child());
+            assert!(
+                cursor.goto_first_child(),
+                "Could not find a child corresponding to any enum branch"
+            );
             loop {
-                let n = cursor.node();
-                match n.kind() {
-                    "Expr_Numbers" => return extract_Expr_Numbers(n, source),
+                let node = cursor.node();
+                match node.kind() {
+                    "Expr_Numbers" => {
+                        return ::rust_sitter::__private::extract_struct_or_variant(
+                            node,
+                            move |cursor, last_idx| {
+                                Expr::Numbers({
+                                    ::rust_sitter::__private::extract_field::<Vec<Number>, _>(
+                                        cursor, source, last_idx, "0", None,
+                                    )
+                                })
+                            },
+                        )
+                    }
                     _ => {
                         if !cursor.goto_next_sibling() {
                             panic!("Could not find a child corresponding to any enum branch")
@@ -101,29 +74,18 @@ mod grammar {
         }
     }
     extern "C" {
-        fn tree_sitter_test() -> rust_sitter::tree_sitter::Language;
+        fn tree_sitter_test() -> ::rust_sitter::tree_sitter::Language;
     }
-    pub fn language() -> rust_sitter::tree_sitter::Language {
+    pub fn language() -> ::rust_sitter::tree_sitter::Language {
         unsafe { tree_sitter_test() }
     }
-    pub fn parse(input: &str) -> core::result::Result<Expr, Vec<rust_sitter::errors::ParseError>> {
-        let mut parser = rust_sitter::tree_sitter::Parser::new();
-        parser.set_language(language()).unwrap();
-        let tree = parser.parse(input, None).unwrap();
-        let root_node = tree.root_node();
-        if root_node.has_error() {
-            let mut errors = vec![];
-            rust_sitter::errors::collect_parsing_errors(&root_node, input.as_bytes(), &mut errors);
-            Err(errors)
-        } else {
-            use rust_sitter::Extract;
-            Ok(<Expr as rust_sitter::Extract<_>>::extract(
-                Some(root_node),
-                input.as_bytes(),
-                0,
-                None,
-            ))
-        }
+    #[doc = r" Parse an input string according to the grammar. Returns either any parsing errors that happened, or a"]
+    #[doc = "[`Expr`]"]
+    #[doc = r" instance containing the parsed structured data."]
+    pub fn parse(
+        input: &str,
+    ) -> core::result::Result<Expr, Vec<::rust_sitter::errors::ParseError>> {
+        ::rust_sitter::__private::parse::<Expr>(input, language)
     }
 }
 

--- a/macro/src/snapshots/rust_sitter_macro__tests__enum_with_unamed_vector.snap
+++ b/macro/src/snapshots/rust_sitter_macro__tests__enum_with_unamed_vector.snap
@@ -23,52 +23,27 @@ mod grammar {
                 source: &[u8],
                 last_idx: &mut usize,
             ) -> u32 {
-                if let Some(cursor) = cursor_opt.as_mut() {
-                    loop {
-                        let n = cursor.node();
-                        if let Some(name) = cursor.field_name() {
-                            if name == "value" {
-                                let node: Option<rust_sitter::tree_sitter::Node> = Some(n);
-                                let out = < rust_sitter :: WithLeaf < u32 > as rust_sitter :: Extract < _ > > :: extract (node , source , * last_idx , Some (& | v | v . parse () . unwrap ())) ;
-                                if !cursor.goto_next_sibling() {
-                                    *cursor_opt = None;
-                                };
-                                *last_idx = n.end_byte();
-                                return out;
-                            } else {
-                                let node: Option<rust_sitter::tree_sitter::Node> = None;
-                                return < rust_sitter :: WithLeaf < u32 > as rust_sitter :: Extract < _ > > :: extract (node , source , * last_idx , Some (& | v | v . parse () . unwrap ())) ;
-                            }
-                        } else {
-                            *last_idx = n.end_byte();
-                        }
-                        if !cursor.goto_next_sibling() {
-                            let node: Option<rust_sitter::tree_sitter::Node> = None;
-                            return < rust_sitter :: WithLeaf < u32 > as rust_sitter :: Extract < _ > > :: extract (node , source , * last_idx , Some (& | v | v . parse () . unwrap ())) ;
-                        }
-                    }
-                } else {
-                    let node: Option<rust_sitter::tree_sitter::Node> = None;
-                    return <rust_sitter::WithLeaf<u32> as rust_sitter::Extract<_>>::extract(
-                        node,
-                        source,
-                        *last_idx,
-                        Some(&|v| v.parse().unwrap()),
-                    );
-                }
+                rust_sitter::__private::extract_field(
+                    cursor_opt,
+                    last_idx,
+                    "value",
+                    move |node, last_idx| {
+                        <rust_sitter::WithLeaf<u32> as rust_sitter::Extract<_>>::extract(
+                            node,
+                            source,
+                            *last_idx,
+                            Some(&|v| v.parse().unwrap()),
+                        )
+                    },
+                )
             }
             #[allow(non_snake_case)]
             fn extract_Number(node: rust_sitter::tree_sitter::Node, source: &[u8]) -> Number {
-                let mut last_idx = node.start_byte();
-                let mut parent_cursor = node.walk();
-                let mut cursor = if parent_cursor.goto_first_child() {
-                    Some(parent_cursor)
-                } else {
-                    None
-                };
-                Number {
-                    value: extract_Number_value(&mut cursor, source, &mut last_idx),
-                }
+                rust_sitter::__private::extract_struct_or_variant(node, move |cursor, last_idx| {
+                    Number {
+                        value: extract_Number_value(cursor, source, last_idx),
+                    }
+                })
             }
             extract_Number(node, source)
         }
@@ -93,53 +68,22 @@ mod grammar {
                 source: &[u8],
                 last_idx: &mut usize,
             ) -> Vec<Number> {
-                if let Some(cursor) = cursor_opt.as_mut() {
-                    loop {
-                        let n = cursor.node();
-                        if let Some(name) = cursor.field_name() {
-                            if name == "0" {
-                                let node: Option<rust_sitter::tree_sitter::Node> = Some(n);
-                                let out = <Vec<Number> as rust_sitter::Extract<_>>::extract(
-                                    node, source, *last_idx, None,
-                                );
-                                if !cursor.goto_next_sibling() {
-                                    *cursor_opt = None;
-                                };
-                                *last_idx = n.end_byte();
-                                return out;
-                            } else {
-                                let node: Option<rust_sitter::tree_sitter::Node> = None;
-                                return <Vec<Number> as rust_sitter::Extract<_>>::extract(
-                                    node, source, *last_idx, None,
-                                );
-                            }
-                        } else {
-                            *last_idx = n.end_byte();
-                        }
-                        if !cursor.goto_next_sibling() {
-                            let node: Option<rust_sitter::tree_sitter::Node> = None;
-                            return <Vec<Number> as rust_sitter::Extract<_>>::extract(
-                                node, source, *last_idx, None,
-                            );
-                        }
-                    }
-                } else {
-                    let node: Option<rust_sitter::tree_sitter::Node> = None;
-                    return <Vec<Number> as rust_sitter::Extract<_>>::extract(
-                        node, source, *last_idx, None,
-                    );
-                }
+                rust_sitter::__private::extract_field(
+                    cursor_opt,
+                    last_idx,
+                    "0",
+                    move |node, last_idx| {
+                        <Vec<Number> as rust_sitter::Extract<_>>::extract(
+                            node, source, *last_idx, None,
+                        )
+                    },
+                )
             }
             #[allow(non_snake_case)]
             fn extract_Expr_Numbers(node: rust_sitter::tree_sitter::Node, source: &[u8]) -> Expr {
-                let mut last_idx = node.start_byte();
-                let mut parent_cursor = node.walk();
-                let mut cursor = if parent_cursor.goto_first_child() {
-                    Some(parent_cursor)
-                } else {
-                    None
-                };
-                Expr::Numbers(extract_Expr_Numbers_0(&mut cursor, source, &mut last_idx))
+                rust_sitter::__private::extract_struct_or_variant(node, move |cursor, last_idx| {
+                    Expr::Numbers(extract_Expr_Numbers_0(cursor, source, last_idx))
+                })
             }
             let mut cursor = node.walk();
             assert!(cursor.goto_first_child());

--- a/macro/src/snapshots/rust_sitter_macro__tests__grammar_unboxed_field.snap
+++ b/macro/src/snapshots/rust_sitter_macro__tests__grammar_unboxed_field.snap
@@ -23,55 +23,24 @@ mod grammar {
                 source: &[u8],
                 last_idx: &mut usize,
             ) -> Expression {
-                if let Some(cursor) = cursor_opt.as_mut() {
-                    loop {
-                        let n = cursor.node();
-                        if let Some(name) = cursor.field_name() {
-                            if name == "e" {
-                                let node: Option<rust_sitter::tree_sitter::Node> = Some(n);
-                                let out = <Expression as rust_sitter::Extract<_>>::extract(
-                                    node, source, *last_idx, None,
-                                );
-                                if !cursor.goto_next_sibling() {
-                                    *cursor_opt = None;
-                                };
-                                *last_idx = n.end_byte();
-                                return out;
-                            } else {
-                                let node: Option<rust_sitter::tree_sitter::Node> = None;
-                                return <Expression as rust_sitter::Extract<_>>::extract(
-                                    node, source, *last_idx, None,
-                                );
-                            }
-                        } else {
-                            *last_idx = n.end_byte();
-                        }
-                        if !cursor.goto_next_sibling() {
-                            let node: Option<rust_sitter::tree_sitter::Node> = None;
-                            return <Expression as rust_sitter::Extract<_>>::extract(
-                                node, source, *last_idx, None,
-                            );
-                        }
-                    }
-                } else {
-                    let node: Option<rust_sitter::tree_sitter::Node> = None;
-                    return <Expression as rust_sitter::Extract<_>>::extract(
-                        node, source, *last_idx, None,
-                    );
-                }
+                rust_sitter::__private::extract_field(
+                    cursor_opt,
+                    last_idx,
+                    "e",
+                    move |node, last_idx| {
+                        <Expression as rust_sitter::Extract<_>>::extract(
+                            node, source, *last_idx, None,
+                        )
+                    },
+                )
             }
             #[allow(non_snake_case)]
             fn extract_Language(node: rust_sitter::tree_sitter::Node, source: &[u8]) -> Language {
-                let mut last_idx = node.start_byte();
-                let mut parent_cursor = node.walk();
-                let mut cursor = if parent_cursor.goto_first_child() {
-                    Some(parent_cursor)
-                } else {
-                    None
-                };
-                Language {
-                    e: extract_Language_e(&mut cursor, source, &mut last_idx),
-                }
+                rust_sitter::__private::extract_struct_or_variant(node, move |cursor, last_idx| {
+                    Language {
+                        e: extract_Language_e(cursor, source, last_idx),
+                    }
+                })
             }
             extract_Language(node, source)
         }
@@ -96,57 +65,28 @@ mod grammar {
                 source: &[u8],
                 last_idx: &mut usize,
             ) -> i32 {
-                if let Some(cursor) = cursor_opt.as_mut() {
-                    loop {
-                        let n = cursor.node();
-                        if let Some(name) = cursor.field_name() {
-                            if name == "0" {
-                                let node: Option<rust_sitter::tree_sitter::Node> = Some(n);
-                                let out = < rust_sitter :: WithLeaf < i32 > as rust_sitter :: Extract < _ > > :: extract (node , source , * last_idx , Some (& | v : & str | v . parse :: < i32 > () . unwrap ())) ;
-                                if !cursor.goto_next_sibling() {
-                                    *cursor_opt = None;
-                                };
-                                *last_idx = n.end_byte();
-                                return out;
-                            } else {
-                                let node: Option<rust_sitter::tree_sitter::Node> = None;
-                                return < rust_sitter :: WithLeaf < i32 > as rust_sitter :: Extract < _ > > :: extract (node , source , * last_idx , Some (& | v : & str | v . parse :: < i32 > () . unwrap ())) ;
-                            }
-                        } else {
-                            *last_idx = n.end_byte();
-                        }
-                        if !cursor.goto_next_sibling() {
-                            let node: Option<rust_sitter::tree_sitter::Node> = None;
-                            return < rust_sitter :: WithLeaf < i32 > as rust_sitter :: Extract < _ > > :: extract (node , source , * last_idx , Some (& | v : & str | v . parse :: < i32 > () . unwrap ())) ;
-                        }
-                    }
-                } else {
-                    let node: Option<rust_sitter::tree_sitter::Node> = None;
-                    return <rust_sitter::WithLeaf<i32> as rust_sitter::Extract<_>>::extract(
-                        node,
-                        source,
-                        *last_idx,
-                        Some(&|v: &str| v.parse::<i32>().unwrap()),
-                    );
-                }
+                rust_sitter::__private::extract_field(
+                    cursor_opt,
+                    last_idx,
+                    "0",
+                    move |node, last_idx| {
+                        <rust_sitter::WithLeaf<i32> as rust_sitter::Extract<_>>::extract(
+                            node,
+                            source,
+                            *last_idx,
+                            Some(&|v: &str| v.parse::<i32>().unwrap()),
+                        )
+                    },
+                )
             }
             #[allow(non_snake_case)]
             fn extract_Expression_Number(
                 node: rust_sitter::tree_sitter::Node,
                 source: &[u8],
             ) -> Expression {
-                let mut last_idx = node.start_byte();
-                let mut parent_cursor = node.walk();
-                let mut cursor = if parent_cursor.goto_first_child() {
-                    Some(parent_cursor)
-                } else {
-                    None
-                };
-                Expression::Number(extract_Expression_Number_0(
-                    &mut cursor,
-                    source,
-                    &mut last_idx,
-                ))
+                rust_sitter::__private::extract_struct_or_variant(node, move |cursor, last_idx| {
+                    Expression::Number(extract_Expression_Number_0(cursor, source, last_idx))
+                })
             }
             let mut cursor = node.walk();
             assert!(cursor.goto_first_child());

--- a/macro/src/snapshots/rust_sitter_macro__tests__grammar_unboxed_field.snap
+++ b/macro/src/snapshots/rust_sitter_macro__tests__grammar_unboxed_field.snap
@@ -1,99 +1,72 @@
 ---
 source: macro/src/lib.rs
-expression: "rustfmt_code(&expand_grammar(parse_quote! {\n                            #[rust_sitter :: grammar(\"test\")] mod grammar\n                            {\n                                #[rust_sitter :: language] pub struct Language\n                                { e : Expression, } pub enum Expression\n                                {\n                                    Number(#[rust_sitter ::\n                                    leaf(pattern = r\"\\d+\", transform = | v : & str | v.parse ::\n                                    < i32 > ().unwrap())] i32),\n                                }\n                            }\n                        }).to_token_stream().to_string())"
+expression: "rustfmt_code(&expand_grammar(parse_quote! {\n                                #[rust_sitter :: grammar(\"test\")] mod grammar\n                                {\n                                    #[rust_sitter :: language] pub struct Language\n                                    { e : Expression, } pub enum Expression\n                                    {\n                                        Number(#[rust_sitter ::\n                                        leaf(pattern = r\"\\d+\", transform = | v : & str | v.parse ::\n                                        < i32 > ().unwrap())] i32),\n                                    }\n                                }\n                            })?.to_token_stream().to_string())"
 ---
 mod grammar {
     pub struct Language {
         e: Expression,
     }
-    impl rust_sitter::Extract<Language> for Language {
+    impl ::rust_sitter::Extract<Language> for Language {
         type LeafFn = ();
         #[allow(non_snake_case)]
         fn extract(
-            node: Option<rust_sitter::tree_sitter::Node>,
+            node: Option<::rust_sitter::tree_sitter::Node>,
             source: &[u8],
             last_idx: usize,
             _leaf_fn: Option<&Self::LeafFn>,
         ) -> Self {
             let node = node.unwrap();
-            #[allow(non_snake_case)]
-            #[allow(clippy::unused_unit)]
-            fn extract_Language_e(
-                cursor_opt: &mut Option<rust_sitter::tree_sitter::TreeCursor>,
-                source: &[u8],
-                last_idx: &mut usize,
-            ) -> Expression {
-                rust_sitter::__private::extract_field(
-                    cursor_opt,
-                    last_idx,
-                    "e",
-                    move |node, last_idx| {
-                        <Expression as rust_sitter::Extract<_>>::extract(
-                            node, source, *last_idx, None,
+            ::rust_sitter::__private::extract_struct_or_variant(node, move |cursor, last_idx| {
+                Language {
+                    e: {
+                        ::rust_sitter::__private::extract_field::<Expression, _>(
+                            cursor, source, last_idx, "e", None,
                         )
                     },
-                )
-            }
-            #[allow(non_snake_case)]
-            fn extract_Language(node: rust_sitter::tree_sitter::Node, source: &[u8]) -> Language {
-                rust_sitter::__private::extract_struct_or_variant(node, move |cursor, last_idx| {
-                    Language {
-                        e: extract_Language_e(cursor, source, last_idx),
-                    }
-                })
-            }
-            extract_Language(node, source)
+                }
+            })
         }
     }
     pub enum Expression {
         Number(i32),
     }
-    impl rust_sitter::Extract<Expression> for Expression {
+    impl ::rust_sitter::Extract<Expression> for Expression {
         type LeafFn = ();
         #[allow(non_snake_case)]
         fn extract(
-            node: Option<rust_sitter::tree_sitter::Node>,
+            node: Option<::rust_sitter::tree_sitter::Node>,
             source: &[u8],
             _last_idx: usize,
             _leaf_fn: Option<&Self::LeafFn>,
         ) -> Self {
             let node = node.unwrap();
-            #[allow(non_snake_case)]
-            #[allow(clippy::unused_unit)]
-            fn extract_Expression_Number_0(
-                cursor_opt: &mut Option<rust_sitter::tree_sitter::TreeCursor>,
-                source: &[u8],
-                last_idx: &mut usize,
-            ) -> i32 {
-                rust_sitter::__private::extract_field(
-                    cursor_opt,
-                    last_idx,
-                    "0",
-                    move |node, last_idx| {
-                        <rust_sitter::WithLeaf<i32> as rust_sitter::Extract<_>>::extract(
-                            node,
-                            source,
-                            *last_idx,
-                            Some(&|v: &str| v.parse::<i32>().unwrap()),
-                        )
-                    },
-                )
-            }
-            #[allow(non_snake_case)]
-            fn extract_Expression_Number(
-                node: rust_sitter::tree_sitter::Node,
-                source: &[u8],
-            ) -> Expression {
-                rust_sitter::__private::extract_struct_or_variant(node, move |cursor, last_idx| {
-                    Expression::Number(extract_Expression_Number_0(cursor, source, last_idx))
-                })
-            }
             let mut cursor = node.walk();
-            assert!(cursor.goto_first_child());
+            assert!(
+                cursor.goto_first_child(),
+                "Could not find a child corresponding to any enum branch"
+            );
             loop {
-                let n = cursor.node();
-                match n.kind() {
-                    "Expression_Number" => return extract_Expression_Number(n, source),
+                let node = cursor.node();
+                match node.kind() {
+                    "Expression_Number" => {
+                        return ::rust_sitter::__private::extract_struct_or_variant(
+                            node,
+                            move |cursor, last_idx| {
+                                Expression::Number({
+                                    ::rust_sitter::__private::extract_field::<
+                                        rust_sitter::WithLeaf<i32>,
+                                        _,
+                                    >(
+                                        cursor,
+                                        source,
+                                        last_idx,
+                                        "0",
+                                        Some(&|v: &str| v.parse::<i32>().unwrap()),
+                                    )
+                                })
+                            },
+                        )
+                    }
                     _ => {
                         if !cursor.goto_next_sibling() {
                             panic!("Could not find a child corresponding to any enum branch")
@@ -104,31 +77,18 @@ mod grammar {
         }
     }
     extern "C" {
-        fn tree_sitter_test() -> rust_sitter::tree_sitter::Language;
+        fn tree_sitter_test() -> ::rust_sitter::tree_sitter::Language;
     }
-    pub fn language() -> rust_sitter::tree_sitter::Language {
+    pub fn language() -> ::rust_sitter::tree_sitter::Language {
         unsafe { tree_sitter_test() }
     }
+    #[doc = r" Parse an input string according to the grammar. Returns either any parsing errors that happened, or a"]
+    #[doc = "[`Language`]"]
+    #[doc = r" instance containing the parsed structured data."]
     pub fn parse(
         input: &str,
-    ) -> core::result::Result<Language, Vec<rust_sitter::errors::ParseError>> {
-        let mut parser = rust_sitter::tree_sitter::Parser::new();
-        parser.set_language(language()).unwrap();
-        let tree = parser.parse(input, None).unwrap();
-        let root_node = tree.root_node();
-        if root_node.has_error() {
-            let mut errors = vec![];
-            rust_sitter::errors::collect_parsing_errors(&root_node, input.as_bytes(), &mut errors);
-            Err(errors)
-        } else {
-            use rust_sitter::Extract;
-            Ok(<Language as rust_sitter::Extract<_>>::extract(
-                Some(root_node),
-                input.as_bytes(),
-                0,
-                None,
-            ))
-        }
+    ) -> core::result::Result<Language, Vec<::rust_sitter::errors::ParseError>> {
+        ::rust_sitter::__private::parse::<Language>(input, language)
     }
 }
 

--- a/macro/src/snapshots/rust_sitter_macro__tests__spanned_in_vec.snap
+++ b/macro/src/snapshots/rust_sitter_macro__tests__spanned_in_vec.snap
@@ -24,59 +24,27 @@ mod grammar {
                 source: &[u8],
                 last_idx: &mut usize,
             ) -> Vec<Spanned<Number>> {
-                if let Some(cursor) = cursor_opt.as_mut() {
-                    loop {
-                        let n = cursor.node();
-                        if let Some(name) = cursor.field_name() {
-                            if name == "numbers" {
-                                let node: Option<rust_sitter::tree_sitter::Node> = Some(n);
-                                let out =
-                                    <Vec<Spanned<Number>> as rust_sitter::Extract<_>>::extract(
-                                        node, source, *last_idx, None,
-                                    );
-                                if !cursor.goto_next_sibling() {
-                                    *cursor_opt = None;
-                                };
-                                *last_idx = n.end_byte();
-                                return out;
-                            } else {
-                                let node: Option<rust_sitter::tree_sitter::Node> = None;
-                                return <Vec<Spanned<Number>> as rust_sitter::Extract<_>>::extract(
-                                    node, source, *last_idx, None,
-                                );
-                            }
-                        } else {
-                            *last_idx = n.end_byte();
-                        }
-                        if !cursor.goto_next_sibling() {
-                            let node: Option<rust_sitter::tree_sitter::Node> = None;
-                            return <Vec<Spanned<Number>> as rust_sitter::Extract<_>>::extract(
-                                node, source, *last_idx, None,
-                            );
-                        }
-                    }
-                } else {
-                    let node: Option<rust_sitter::tree_sitter::Node> = None;
-                    return <Vec<Spanned<Number>> as rust_sitter::Extract<_>>::extract(
-                        node, source, *last_idx, None,
-                    );
-                }
+                rust_sitter::__private::extract_field(
+                    cursor_opt,
+                    last_idx,
+                    "numbers",
+                    move |node, last_idx| {
+                        <Vec<Spanned<Number>> as rust_sitter::Extract<_>>::extract(
+                            node, source, *last_idx, None,
+                        )
+                    },
+                )
             }
             #[allow(non_snake_case)]
             fn extract_NumberList(
                 node: rust_sitter::tree_sitter::Node,
                 source: &[u8],
             ) -> NumberList {
-                let mut last_idx = node.start_byte();
-                let mut parent_cursor = node.walk();
-                let mut cursor = if parent_cursor.goto_first_child() {
-                    Some(parent_cursor)
-                } else {
-                    None
-                };
-                NumberList {
-                    numbers: extract_NumberList_numbers(&mut cursor, source, &mut last_idx),
-                }
+                rust_sitter::__private::extract_struct_or_variant(node, move |cursor, last_idx| {
+                    NumberList {
+                        numbers: extract_NumberList_numbers(cursor, source, last_idx),
+                    }
+                })
             }
             extract_NumberList(node, source)
         }
@@ -101,52 +69,27 @@ mod grammar {
                 source: &[u8],
                 last_idx: &mut usize,
             ) -> i32 {
-                if let Some(cursor) = cursor_opt.as_mut() {
-                    loop {
-                        let n = cursor.node();
-                        if let Some(name) = cursor.field_name() {
-                            if name == "v" {
-                                let node: Option<rust_sitter::tree_sitter::Node> = Some(n);
-                                let out = < rust_sitter :: WithLeaf < i32 > as rust_sitter :: Extract < _ > > :: extract (node , source , * last_idx , Some (& | v | v . parse () . unwrap ())) ;
-                                if !cursor.goto_next_sibling() {
-                                    *cursor_opt = None;
-                                };
-                                *last_idx = n.end_byte();
-                                return out;
-                            } else {
-                                let node: Option<rust_sitter::tree_sitter::Node> = None;
-                                return < rust_sitter :: WithLeaf < i32 > as rust_sitter :: Extract < _ > > :: extract (node , source , * last_idx , Some (& | v | v . parse () . unwrap ())) ;
-                            }
-                        } else {
-                            *last_idx = n.end_byte();
-                        }
-                        if !cursor.goto_next_sibling() {
-                            let node: Option<rust_sitter::tree_sitter::Node> = None;
-                            return < rust_sitter :: WithLeaf < i32 > as rust_sitter :: Extract < _ > > :: extract (node , source , * last_idx , Some (& | v | v . parse () . unwrap ())) ;
-                        }
-                    }
-                } else {
-                    let node: Option<rust_sitter::tree_sitter::Node> = None;
-                    return <rust_sitter::WithLeaf<i32> as rust_sitter::Extract<_>>::extract(
-                        node,
-                        source,
-                        *last_idx,
-                        Some(&|v| v.parse().unwrap()),
-                    );
-                }
+                rust_sitter::__private::extract_field(
+                    cursor_opt,
+                    last_idx,
+                    "v",
+                    move |node, last_idx| {
+                        <rust_sitter::WithLeaf<i32> as rust_sitter::Extract<_>>::extract(
+                            node,
+                            source,
+                            *last_idx,
+                            Some(&|v| v.parse().unwrap()),
+                        )
+                    },
+                )
             }
             #[allow(non_snake_case)]
             fn extract_Number(node: rust_sitter::tree_sitter::Node, source: &[u8]) -> Number {
-                let mut last_idx = node.start_byte();
-                let mut parent_cursor = node.walk();
-                let mut cursor = if parent_cursor.goto_first_child() {
-                    Some(parent_cursor)
-                } else {
-                    None
-                };
-                Number {
-                    v: extract_Number_v(&mut cursor, source, &mut last_idx),
-                }
+                rust_sitter::__private::extract_struct_or_variant(node, move |cursor, last_idx| {
+                    Number {
+                        v: extract_Number_v(cursor, source, last_idx),
+                    }
+                })
             }
             extract_Number(node, source)
         }
@@ -171,56 +114,25 @@ mod grammar {
                 source: &[u8],
                 last_idx: &mut usize,
             ) -> () {
-                if let Some(cursor) = cursor_opt.as_mut() {
-                    loop {
-                        let n = cursor.node();
-                        if let Some(name) = cursor.field_name() {
-                            if name == "_whitespace" {
-                                let node: Option<rust_sitter::tree_sitter::Node> = Some(n);
-                                let out = <() as rust_sitter::Extract<_>>::extract(
-                                    node, source, *last_idx, None,
-                                );
-                                if !cursor.goto_next_sibling() {
-                                    *cursor_opt = None;
-                                };
-                                *last_idx = n.end_byte();
-                                return out;
-                            } else {
-                                let node: Option<rust_sitter::tree_sitter::Node> = None;
-                                return <() as rust_sitter::Extract<_>>::extract(
-                                    node, source, *last_idx, None,
-                                );
-                            }
-                        } else {
-                            *last_idx = n.end_byte();
-                        }
-                        if !cursor.goto_next_sibling() {
-                            let node: Option<rust_sitter::tree_sitter::Node> = None;
-                            return <() as rust_sitter::Extract<_>>::extract(
-                                node, source, *last_idx, None,
-                            );
-                        }
-                    }
-                } else {
-                    let node: Option<rust_sitter::tree_sitter::Node> = None;
-                    return <() as rust_sitter::Extract<_>>::extract(node, source, *last_idx, None);
-                }
+                rust_sitter::__private::extract_field(
+                    cursor_opt,
+                    last_idx,
+                    "_whitespace",
+                    move |node, last_idx| {
+                        <() as rust_sitter::Extract<_>>::extract(node, source, *last_idx, None)
+                    },
+                )
             }
             #[allow(non_snake_case)]
             fn extract_Whitespace(
                 node: rust_sitter::tree_sitter::Node,
                 source: &[u8],
             ) -> Whitespace {
-                let mut last_idx = node.start_byte();
-                let mut parent_cursor = node.walk();
-                let mut cursor = if parent_cursor.goto_first_child() {
-                    Some(parent_cursor)
-                } else {
-                    None
-                };
-                Whitespace {
-                    _whitespace: extract_Whitespace__whitespace(&mut cursor, source, &mut last_idx),
-                }
+                rust_sitter::__private::extract_struct_or_variant(node, move |cursor, last_idx| {
+                    Whitespace {
+                        _whitespace: extract_Whitespace__whitespace(cursor, source, last_idx),
+                    }
+                })
             }
             extract_Whitespace(node, source)
         }

--- a/macro/src/snapshots/rust_sitter_macro__tests__spanned_in_vec.snap
+++ b/macro/src/snapshots/rust_sitter_macro__tests__spanned_in_vec.snap
@@ -1,168 +1,102 @@
 ---
 source: macro/src/lib.rs
-expression: "rustfmt_code(&expand_grammar(parse_quote! {\n                            #[rust_sitter :: grammar(\"test\")] mod grammar\n                            {\n                                use rust_sitter :: Spanned ; #[rust_sitter :: language] pub\n                                struct NumberList { numbers : Vec < Spanned < Number >>, }\n                                pub struct Number\n                                {\n                                    #[rust_sitter ::\n                                    leaf(pattern = r\"\\d+\", transform = | v |\n                                    v.parse().unwrap())] v : i32\n                                } #[rust_sitter :: extra] struct Whitespace\n                                {\n                                    #[rust_sitter :: leaf(pattern = r\"\\s\")] _whitespace : (),\n                                }\n                            }\n                        }).to_token_stream().to_string())"
+expression: "rustfmt_code(&expand_grammar(parse_quote! {\n                                #[rust_sitter :: grammar(\"test\")] mod grammar\n                                {\n                                    use rust_sitter :: Spanned ; #[rust_sitter :: language] pub\n                                    struct NumberList { numbers : Vec < Spanned < Number >>, }\n                                    pub struct Number\n                                    {\n                                        #[rust_sitter ::\n                                        leaf(pattern = r\"\\d+\", transform = | v |\n                                        v.parse().unwrap())] v : i32\n                                    } #[rust_sitter :: extra] struct Whitespace\n                                    {\n                                        #[rust_sitter :: leaf(pattern = r\"\\s\")] _whitespace : (),\n                                    }\n                                }\n                            })?.to_token_stream().to_string())"
 ---
 mod grammar {
     use rust_sitter::Spanned;
     pub struct NumberList {
         numbers: Vec<Spanned<Number>>,
     }
-    impl rust_sitter::Extract<NumberList> for NumberList {
+    impl ::rust_sitter::Extract<NumberList> for NumberList {
         type LeafFn = ();
         #[allow(non_snake_case)]
         fn extract(
-            node: Option<rust_sitter::tree_sitter::Node>,
+            node: Option<::rust_sitter::tree_sitter::Node>,
             source: &[u8],
             last_idx: usize,
             _leaf_fn: Option<&Self::LeafFn>,
         ) -> Self {
             let node = node.unwrap();
-            #[allow(non_snake_case)]
-            #[allow(clippy::unused_unit)]
-            fn extract_NumberList_numbers(
-                cursor_opt: &mut Option<rust_sitter::tree_sitter::TreeCursor>,
-                source: &[u8],
-                last_idx: &mut usize,
-            ) -> Vec<Spanned<Number>> {
-                rust_sitter::__private::extract_field(
-                    cursor_opt,
-                    last_idx,
-                    "numbers",
-                    move |node, last_idx| {
-                        <Vec<Spanned<Number>> as rust_sitter::Extract<_>>::extract(
-                            node, source, *last_idx, None,
+            ::rust_sitter::__private::extract_struct_or_variant(node, move |cursor, last_idx| {
+                NumberList {
+                    numbers: {
+                        ::rust_sitter::__private::extract_field::<Vec<Spanned<Number>>, _>(
+                            cursor, source, last_idx, "numbers", None,
                         )
                     },
-                )
-            }
-            #[allow(non_snake_case)]
-            fn extract_NumberList(
-                node: rust_sitter::tree_sitter::Node,
-                source: &[u8],
-            ) -> NumberList {
-                rust_sitter::__private::extract_struct_or_variant(node, move |cursor, last_idx| {
-                    NumberList {
-                        numbers: extract_NumberList_numbers(cursor, source, last_idx),
-                    }
-                })
-            }
-            extract_NumberList(node, source)
+                }
+            })
         }
     }
     pub struct Number {
         v: i32,
     }
-    impl rust_sitter::Extract<Number> for Number {
+    impl ::rust_sitter::Extract<Number> for Number {
         type LeafFn = ();
         #[allow(non_snake_case)]
         fn extract(
-            node: Option<rust_sitter::tree_sitter::Node>,
+            node: Option<::rust_sitter::tree_sitter::Node>,
             source: &[u8],
             last_idx: usize,
             _leaf_fn: Option<&Self::LeafFn>,
         ) -> Self {
             let node = node.unwrap();
-            #[allow(non_snake_case)]
-            #[allow(clippy::unused_unit)]
-            fn extract_Number_v(
-                cursor_opt: &mut Option<rust_sitter::tree_sitter::TreeCursor>,
-                source: &[u8],
-                last_idx: &mut usize,
-            ) -> i32 {
-                rust_sitter::__private::extract_field(
-                    cursor_opt,
-                    last_idx,
-                    "v",
-                    move |node, last_idx| {
-                        <rust_sitter::WithLeaf<i32> as rust_sitter::Extract<_>>::extract(
-                            node,
+            ::rust_sitter::__private::extract_struct_or_variant(node, move |cursor, last_idx| {
+                Number {
+                    v: {
+                        ::rust_sitter::__private::extract_field::<rust_sitter::WithLeaf<i32>, _>(
+                            cursor,
                             source,
-                            *last_idx,
+                            last_idx,
+                            "v",
                             Some(&|v| v.parse().unwrap()),
                         )
                     },
-                )
-            }
-            #[allow(non_snake_case)]
-            fn extract_Number(node: rust_sitter::tree_sitter::Node, source: &[u8]) -> Number {
-                rust_sitter::__private::extract_struct_or_variant(node, move |cursor, last_idx| {
-                    Number {
-                        v: extract_Number_v(cursor, source, last_idx),
-                    }
-                })
-            }
-            extract_Number(node, source)
+                }
+            })
         }
     }
     struct Whitespace {
         _whitespace: (),
     }
-    impl rust_sitter::Extract<Whitespace> for Whitespace {
+    impl ::rust_sitter::Extract<Whitespace> for Whitespace {
         type LeafFn = ();
         #[allow(non_snake_case)]
         fn extract(
-            node: Option<rust_sitter::tree_sitter::Node>,
+            node: Option<::rust_sitter::tree_sitter::Node>,
             source: &[u8],
             last_idx: usize,
             _leaf_fn: Option<&Self::LeafFn>,
         ) -> Self {
             let node = node.unwrap();
-            #[allow(non_snake_case)]
-            #[allow(clippy::unused_unit)]
-            fn extract_Whitespace__whitespace(
-                cursor_opt: &mut Option<rust_sitter::tree_sitter::TreeCursor>,
-                source: &[u8],
-                last_idx: &mut usize,
-            ) -> () {
-                rust_sitter::__private::extract_field(
-                    cursor_opt,
-                    last_idx,
-                    "_whitespace",
-                    move |node, last_idx| {
-                        <() as rust_sitter::Extract<_>>::extract(node, source, *last_idx, None)
+            ::rust_sitter::__private::extract_struct_or_variant(node, move |cursor, last_idx| {
+                Whitespace {
+                    _whitespace: {
+                        ::rust_sitter::__private::extract_field::<(), _>(
+                            cursor,
+                            source,
+                            last_idx,
+                            "_whitespace",
+                            None,
+                        )
                     },
-                )
-            }
-            #[allow(non_snake_case)]
-            fn extract_Whitespace(
-                node: rust_sitter::tree_sitter::Node,
-                source: &[u8],
-            ) -> Whitespace {
-                rust_sitter::__private::extract_struct_or_variant(node, move |cursor, last_idx| {
-                    Whitespace {
-                        _whitespace: extract_Whitespace__whitespace(cursor, source, last_idx),
-                    }
-                })
-            }
-            extract_Whitespace(node, source)
+                }
+            })
         }
     }
     extern "C" {
-        fn tree_sitter_test() -> rust_sitter::tree_sitter::Language;
+        fn tree_sitter_test() -> ::rust_sitter::tree_sitter::Language;
     }
-    pub fn language() -> rust_sitter::tree_sitter::Language {
+    pub fn language() -> ::rust_sitter::tree_sitter::Language {
         unsafe { tree_sitter_test() }
     }
+    #[doc = r" Parse an input string according to the grammar. Returns either any parsing errors that happened, or a"]
+    #[doc = "[`NumberList`]"]
+    #[doc = r" instance containing the parsed structured data."]
     pub fn parse(
         input: &str,
-    ) -> core::result::Result<NumberList, Vec<rust_sitter::errors::ParseError>> {
-        let mut parser = rust_sitter::tree_sitter::Parser::new();
-        parser.set_language(language()).unwrap();
-        let tree = parser.parse(input, None).unwrap();
-        let root_node = tree.root_node();
-        if root_node.has_error() {
-            let mut errors = vec![];
-            rust_sitter::errors::collect_parsing_errors(&root_node, input.as_bytes(), &mut errors);
-            Err(errors)
-        } else {
-            use rust_sitter::Extract;
-            Ok(<NumberList as rust_sitter::Extract<_>>::extract(
-                Some(root_node),
-                input.as_bytes(),
-                0,
-                None,
-            ))
-        }
+    ) -> core::result::Result<NumberList, Vec<::rust_sitter::errors::ParseError>> {
+        ::rust_sitter::__private::parse::<NumberList>(input, language)
     }
 }
 

--- a/macro/src/snapshots/rust_sitter_macro__tests__struct_extra.snap
+++ b/macro/src/snapshots/rust_sitter_macro__tests__struct_extra.snap
@@ -1,57 +1,44 @@
 ---
 source: macro/src/lib.rs
-expression: "rustfmt_code(&expand_grammar(parse_quote! {\n                            #[rust_sitter :: grammar(\"test\")] mod grammar\n                            {\n                                #[rust_sitter :: language] pub enum Expression\n                                {\n                                    Number(#[rust_sitter ::\n                                    leaf(pattern = r\"\\d+\", transform = | v |\n                                    v.parse().unwrap())] i32,),\n                                } #[rust_sitter :: extra] struct Whitespace\n                                {\n                                    #[rust_sitter :: leaf(pattern = r\"\\s\")] _whitespace : (),\n                                }\n                            }\n                        }).to_token_stream().to_string())"
+expression: "rustfmt_code(&expand_grammar(parse_quote! {\n                                #[rust_sitter :: grammar(\"test\")] mod grammar\n                                {\n                                    #[rust_sitter :: language] pub enum Expression\n                                    {\n                                        Number(#[rust_sitter ::\n                                        leaf(pattern = r\"\\d+\", transform = | v |\n                                        v.parse().unwrap())] i32,),\n                                    } #[rust_sitter :: extra] struct Whitespace\n                                    {\n                                        #[rust_sitter :: leaf(pattern = r\"\\s\")] _whitespace : (),\n                                    }\n                                }\n                            })?.to_token_stream().to_string())"
 ---
 mod grammar {
     pub enum Expression {
         Number(i32),
     }
-    impl rust_sitter::Extract<Expression> for Expression {
+    impl ::rust_sitter::Extract<Expression> for Expression {
         type LeafFn = ();
         #[allow(non_snake_case)]
         fn extract(
-            node: Option<rust_sitter::tree_sitter::Node>,
+            node: Option<::rust_sitter::tree_sitter::Node>,
             source: &[u8],
             _last_idx: usize,
             _leaf_fn: Option<&Self::LeafFn>,
         ) -> Self {
             let node = node.unwrap();
-            #[allow(non_snake_case)]
-            #[allow(clippy::unused_unit)]
-            fn extract_Expression_Number_0(
-                cursor_opt: &mut Option<rust_sitter::tree_sitter::TreeCursor>,
-                source: &[u8],
-                last_idx: &mut usize,
-            ) -> i32 {
-                rust_sitter::__private::extract_field(
-                    cursor_opt,
-                    last_idx,
-                    "0",
-                    move |node, last_idx| {
-                        <rust_sitter::WithLeaf<i32> as rust_sitter::Extract<_>>::extract(
-                            node,
-                            source,
-                            *last_idx,
-                            Some(&|v| v.parse().unwrap()),
-                        )
-                    },
-                )
-            }
-            #[allow(non_snake_case)]
-            fn extract_Expression_Number(
-                node: rust_sitter::tree_sitter::Node,
-                source: &[u8],
-            ) -> Expression {
-                rust_sitter::__private::extract_struct_or_variant(node, move |cursor, last_idx| {
-                    Expression::Number(extract_Expression_Number_0(cursor, source, last_idx))
-                })
-            }
             let mut cursor = node.walk();
-            assert!(cursor.goto_first_child());
+            assert!(
+                cursor.goto_first_child(),
+                "Could not find a child corresponding to any enum branch"
+            );
             loop {
-                let n = cursor.node();
-                match n.kind() {
-                    "Expression_Number" => return extract_Expression_Number(n, source),
+                let node = cursor.node();
+                match node.kind() {
+                    "Expression_Number" => {
+                        return ::rust_sitter::__private::extract_struct_or_variant(
+                            node,
+                            move |cursor, last_idx| {
+                                Expression::Number({
+                                    ::rust_sitter::__private::extract_field::<
+                                        rust_sitter::WithLeaf<i32>,
+                                        _,
+                                    >(
+                                        cursor, source, last_idx, "0", Some(&|v| v.parse().unwrap())
+                                    )
+                                })
+                            },
+                        )
+                    }
                     _ => {
                         if !cursor.goto_next_sibling() {
                             panic!("Could not find a child corresponding to any enum branch")
@@ -64,72 +51,44 @@ mod grammar {
     struct Whitespace {
         _whitespace: (),
     }
-    impl rust_sitter::Extract<Whitespace> for Whitespace {
+    impl ::rust_sitter::Extract<Whitespace> for Whitespace {
         type LeafFn = ();
         #[allow(non_snake_case)]
         fn extract(
-            node: Option<rust_sitter::tree_sitter::Node>,
+            node: Option<::rust_sitter::tree_sitter::Node>,
             source: &[u8],
             last_idx: usize,
             _leaf_fn: Option<&Self::LeafFn>,
         ) -> Self {
             let node = node.unwrap();
-            #[allow(non_snake_case)]
-            #[allow(clippy::unused_unit)]
-            fn extract_Whitespace__whitespace(
-                cursor_opt: &mut Option<rust_sitter::tree_sitter::TreeCursor>,
-                source: &[u8],
-                last_idx: &mut usize,
-            ) -> () {
-                rust_sitter::__private::extract_field(
-                    cursor_opt,
-                    last_idx,
-                    "_whitespace",
-                    move |node, last_idx| {
-                        <() as rust_sitter::Extract<_>>::extract(node, source, *last_idx, None)
+            ::rust_sitter::__private::extract_struct_or_variant(node, move |cursor, last_idx| {
+                Whitespace {
+                    _whitespace: {
+                        ::rust_sitter::__private::extract_field::<(), _>(
+                            cursor,
+                            source,
+                            last_idx,
+                            "_whitespace",
+                            None,
+                        )
                     },
-                )
-            }
-            #[allow(non_snake_case)]
-            fn extract_Whitespace(
-                node: rust_sitter::tree_sitter::Node,
-                source: &[u8],
-            ) -> Whitespace {
-                rust_sitter::__private::extract_struct_or_variant(node, move |cursor, last_idx| {
-                    Whitespace {
-                        _whitespace: extract_Whitespace__whitespace(cursor, source, last_idx),
-                    }
-                })
-            }
-            extract_Whitespace(node, source)
+                }
+            })
         }
     }
     extern "C" {
-        fn tree_sitter_test() -> rust_sitter::tree_sitter::Language;
+        fn tree_sitter_test() -> ::rust_sitter::tree_sitter::Language;
     }
-    pub fn language() -> rust_sitter::tree_sitter::Language {
+    pub fn language() -> ::rust_sitter::tree_sitter::Language {
         unsafe { tree_sitter_test() }
     }
+    #[doc = r" Parse an input string according to the grammar. Returns either any parsing errors that happened, or a"]
+    #[doc = "[`Expression`]"]
+    #[doc = r" instance containing the parsed structured data."]
     pub fn parse(
         input: &str,
-    ) -> core::result::Result<Expression, Vec<rust_sitter::errors::ParseError>> {
-        let mut parser = rust_sitter::tree_sitter::Parser::new();
-        parser.set_language(language()).unwrap();
-        let tree = parser.parse(input, None).unwrap();
-        let root_node = tree.root_node();
-        if root_node.has_error() {
-            let mut errors = vec![];
-            rust_sitter::errors::collect_parsing_errors(&root_node, input.as_bytes(), &mut errors);
-            Err(errors)
-        } else {
-            use rust_sitter::Extract;
-            Ok(<Expression as rust_sitter::Extract<_>>::extract(
-                Some(root_node),
-                input.as_bytes(),
-                0,
-                None,
-            ))
-        }
+    ) -> core::result::Result<Expression, Vec<::rust_sitter::errors::ParseError>> {
+        ::rust_sitter::__private::parse::<Expression>(input, language)
     }
 }
 

--- a/macro/src/snapshots/rust_sitter_macro__tests__struct_extra.snap
+++ b/macro/src/snapshots/rust_sitter_macro__tests__struct_extra.snap
@@ -23,57 +23,28 @@ mod grammar {
                 source: &[u8],
                 last_idx: &mut usize,
             ) -> i32 {
-                if let Some(cursor) = cursor_opt.as_mut() {
-                    loop {
-                        let n = cursor.node();
-                        if let Some(name) = cursor.field_name() {
-                            if name == "0" {
-                                let node: Option<rust_sitter::tree_sitter::Node> = Some(n);
-                                let out = < rust_sitter :: WithLeaf < i32 > as rust_sitter :: Extract < _ > > :: extract (node , source , * last_idx , Some (& | v | v . parse () . unwrap ())) ;
-                                if !cursor.goto_next_sibling() {
-                                    *cursor_opt = None;
-                                };
-                                *last_idx = n.end_byte();
-                                return out;
-                            } else {
-                                let node: Option<rust_sitter::tree_sitter::Node> = None;
-                                return < rust_sitter :: WithLeaf < i32 > as rust_sitter :: Extract < _ > > :: extract (node , source , * last_idx , Some (& | v | v . parse () . unwrap ())) ;
-                            }
-                        } else {
-                            *last_idx = n.end_byte();
-                        }
-                        if !cursor.goto_next_sibling() {
-                            let node: Option<rust_sitter::tree_sitter::Node> = None;
-                            return < rust_sitter :: WithLeaf < i32 > as rust_sitter :: Extract < _ > > :: extract (node , source , * last_idx , Some (& | v | v . parse () . unwrap ())) ;
-                        }
-                    }
-                } else {
-                    let node: Option<rust_sitter::tree_sitter::Node> = None;
-                    return <rust_sitter::WithLeaf<i32> as rust_sitter::Extract<_>>::extract(
-                        node,
-                        source,
-                        *last_idx,
-                        Some(&|v| v.parse().unwrap()),
-                    );
-                }
+                rust_sitter::__private::extract_field(
+                    cursor_opt,
+                    last_idx,
+                    "0",
+                    move |node, last_idx| {
+                        <rust_sitter::WithLeaf<i32> as rust_sitter::Extract<_>>::extract(
+                            node,
+                            source,
+                            *last_idx,
+                            Some(&|v| v.parse().unwrap()),
+                        )
+                    },
+                )
             }
             #[allow(non_snake_case)]
             fn extract_Expression_Number(
                 node: rust_sitter::tree_sitter::Node,
                 source: &[u8],
             ) -> Expression {
-                let mut last_idx = node.start_byte();
-                let mut parent_cursor = node.walk();
-                let mut cursor = if parent_cursor.goto_first_child() {
-                    Some(parent_cursor)
-                } else {
-                    None
-                };
-                Expression::Number(extract_Expression_Number_0(
-                    &mut cursor,
-                    source,
-                    &mut last_idx,
-                ))
+                rust_sitter::__private::extract_struct_or_variant(node, move |cursor, last_idx| {
+                    Expression::Number(extract_Expression_Number_0(cursor, source, last_idx))
+                })
             }
             let mut cursor = node.walk();
             assert!(cursor.goto_first_child());
@@ -110,56 +81,25 @@ mod grammar {
                 source: &[u8],
                 last_idx: &mut usize,
             ) -> () {
-                if let Some(cursor) = cursor_opt.as_mut() {
-                    loop {
-                        let n = cursor.node();
-                        if let Some(name) = cursor.field_name() {
-                            if name == "_whitespace" {
-                                let node: Option<rust_sitter::tree_sitter::Node> = Some(n);
-                                let out = <() as rust_sitter::Extract<_>>::extract(
-                                    node, source, *last_idx, None,
-                                );
-                                if !cursor.goto_next_sibling() {
-                                    *cursor_opt = None;
-                                };
-                                *last_idx = n.end_byte();
-                                return out;
-                            } else {
-                                let node: Option<rust_sitter::tree_sitter::Node> = None;
-                                return <() as rust_sitter::Extract<_>>::extract(
-                                    node, source, *last_idx, None,
-                                );
-                            }
-                        } else {
-                            *last_idx = n.end_byte();
-                        }
-                        if !cursor.goto_next_sibling() {
-                            let node: Option<rust_sitter::tree_sitter::Node> = None;
-                            return <() as rust_sitter::Extract<_>>::extract(
-                                node, source, *last_idx, None,
-                            );
-                        }
-                    }
-                } else {
-                    let node: Option<rust_sitter::tree_sitter::Node> = None;
-                    return <() as rust_sitter::Extract<_>>::extract(node, source, *last_idx, None);
-                }
+                rust_sitter::__private::extract_field(
+                    cursor_opt,
+                    last_idx,
+                    "_whitespace",
+                    move |node, last_idx| {
+                        <() as rust_sitter::Extract<_>>::extract(node, source, *last_idx, None)
+                    },
+                )
             }
             #[allow(non_snake_case)]
             fn extract_Whitespace(
                 node: rust_sitter::tree_sitter::Node,
                 source: &[u8],
             ) -> Whitespace {
-                let mut last_idx = node.start_byte();
-                let mut parent_cursor = node.walk();
-                let mut cursor = if parent_cursor.goto_first_child() {
-                    Some(parent_cursor)
-                } else {
-                    None
-                };
-                Whitespace {
-                    _whitespace: extract_Whitespace__whitespace(&mut cursor, source, &mut last_idx),
-                }
+                rust_sitter::__private::extract_struct_or_variant(node, move |cursor, last_idx| {
+                    Whitespace {
+                        _whitespace: extract_Whitespace__whitespace(cursor, source, last_idx),
+                    }
+                })
             }
             extract_Whitespace(node, source)
         }

--- a/macro/src/snapshots/rust_sitter_macro__tests__struct_optional.snap
+++ b/macro/src/snapshots/rust_sitter_macro__tests__struct_optional.snap
@@ -1,144 +1,82 @@
 ---
 source: macro/src/lib.rs
-expression: "rustfmt_code(&expand_grammar(parse_quote! {\n                            #[rust_sitter :: grammar(\"test\")] mod grammar\n                            {\n                                #[rust_sitter :: language] pub struct Language\n                                {\n                                    #[rust_sitter ::\n                                    leaf(pattern = r\"\\d+\", transform = | v |\n                                    v.parse().unwrap())] v : Option < i32 >, t : Option < Number\n                                    >,\n                                } pub struct Number\n                                {\n                                    #[rust_sitter ::\n                                    leaf(pattern = r\"\\d+\", transform = | v |\n                                    v.parse().unwrap())] v : i32\n                                }\n                            }\n                        }).to_token_stream().to_string())"
+expression: "rustfmt_code(&expand_grammar(parse_quote! {\n                                #[rust_sitter :: grammar(\"test\")] mod grammar\n                                {\n                                    #[rust_sitter :: language] pub struct Language\n                                    {\n                                        #[rust_sitter ::\n                                        leaf(pattern = r\"\\d+\", transform = | v |\n                                        v.parse().unwrap())] v : Option < i32 >, t : Option < Number\n                                        >,\n                                    } pub struct Number\n                                    {\n                                        #[rust_sitter ::\n                                        leaf(pattern = r\"\\d+\", transform = | v |\n                                        v.parse().unwrap())] v : i32\n                                    }\n                                }\n                            })?.to_token_stream().to_string())"
 ---
 mod grammar {
     pub struct Language {
         v: Option<i32>,
         t: Option<Number>,
     }
-    impl rust_sitter::Extract<Language> for Language {
+    impl ::rust_sitter::Extract<Language> for Language {
         type LeafFn = ();
         #[allow(non_snake_case)]
         fn extract(
-            node: Option<rust_sitter::tree_sitter::Node>,
+            node: Option<::rust_sitter::tree_sitter::Node>,
             source: &[u8],
             last_idx: usize,
             _leaf_fn: Option<&Self::LeafFn>,
         ) -> Self {
             let node = node.unwrap();
-            #[allow(non_snake_case)]
-            #[allow(clippy::unused_unit)]
-            fn extract_Language_v(
-                cursor_opt: &mut Option<rust_sitter::tree_sitter::TreeCursor>,
-                source: &[u8],
-                last_idx: &mut usize,
-            ) -> Option<i32> {
-                rust_sitter::__private::extract_field(
-                    cursor_opt,
-                    last_idx,
-                    "v",
-                    move |node, last_idx| {
-                        <Option<rust_sitter::WithLeaf<i32>> as rust_sitter::Extract<_>>::extract(
-                            node,
-                            source,
-                            *last_idx,
-                            Some(&|v| v.parse().unwrap()),
+            ::rust_sitter::__private::extract_struct_or_variant(node, move |cursor, last_idx| {
+                Language {
+                    v: {
+                        ::rust_sitter::__private::extract_field::<
+                            Option<rust_sitter::WithLeaf<i32>>,
+                            _,
+                        >(
+                            cursor, source, last_idx, "v", Some(&|v| v.parse().unwrap())
                         )
                     },
-                )
-            }
-            #[allow(non_snake_case)]
-            #[allow(clippy::unused_unit)]
-            fn extract_Language_t(
-                cursor_opt: &mut Option<rust_sitter::tree_sitter::TreeCursor>,
-                source: &[u8],
-                last_idx: &mut usize,
-            ) -> Option<Number> {
-                rust_sitter::__private::extract_field(
-                    cursor_opt,
-                    last_idx,
-                    "t",
-                    move |node, last_idx| {
-                        <Option<Number> as rust_sitter::Extract<_>>::extract(
-                            node, source, *last_idx, None,
+                    t: {
+                        ::rust_sitter::__private::extract_field::<Option<Number>, _>(
+                            cursor, source, last_idx, "t", None,
                         )
                     },
-                )
-            }
-            #[allow(non_snake_case)]
-            fn extract_Language(node: rust_sitter::tree_sitter::Node, source: &[u8]) -> Language {
-                rust_sitter::__private::extract_struct_or_variant(node, move |cursor, last_idx| {
-                    Language {
-                        v: extract_Language_v(cursor, source, last_idx),
-                        t: extract_Language_t(cursor, source, last_idx),
-                    }
-                })
-            }
-            extract_Language(node, source)
+                }
+            })
         }
     }
     pub struct Number {
         v: i32,
     }
-    impl rust_sitter::Extract<Number> for Number {
+    impl ::rust_sitter::Extract<Number> for Number {
         type LeafFn = ();
         #[allow(non_snake_case)]
         fn extract(
-            node: Option<rust_sitter::tree_sitter::Node>,
+            node: Option<::rust_sitter::tree_sitter::Node>,
             source: &[u8],
             last_idx: usize,
             _leaf_fn: Option<&Self::LeafFn>,
         ) -> Self {
             let node = node.unwrap();
-            #[allow(non_snake_case)]
-            #[allow(clippy::unused_unit)]
-            fn extract_Number_v(
-                cursor_opt: &mut Option<rust_sitter::tree_sitter::TreeCursor>,
-                source: &[u8],
-                last_idx: &mut usize,
-            ) -> i32 {
-                rust_sitter::__private::extract_field(
-                    cursor_opt,
-                    last_idx,
-                    "v",
-                    move |node, last_idx| {
-                        <rust_sitter::WithLeaf<i32> as rust_sitter::Extract<_>>::extract(
-                            node,
+            ::rust_sitter::__private::extract_struct_or_variant(node, move |cursor, last_idx| {
+                Number {
+                    v: {
+                        ::rust_sitter::__private::extract_field::<rust_sitter::WithLeaf<i32>, _>(
+                            cursor,
                             source,
-                            *last_idx,
+                            last_idx,
+                            "v",
                             Some(&|v| v.parse().unwrap()),
                         )
                     },
-                )
-            }
-            #[allow(non_snake_case)]
-            fn extract_Number(node: rust_sitter::tree_sitter::Node, source: &[u8]) -> Number {
-                rust_sitter::__private::extract_struct_or_variant(node, move |cursor, last_idx| {
-                    Number {
-                        v: extract_Number_v(cursor, source, last_idx),
-                    }
-                })
-            }
-            extract_Number(node, source)
+                }
+            })
         }
     }
     extern "C" {
-        fn tree_sitter_test() -> rust_sitter::tree_sitter::Language;
+        fn tree_sitter_test() -> ::rust_sitter::tree_sitter::Language;
     }
-    pub fn language() -> rust_sitter::tree_sitter::Language {
+    pub fn language() -> ::rust_sitter::tree_sitter::Language {
         unsafe { tree_sitter_test() }
     }
+    #[doc = r" Parse an input string according to the grammar. Returns either any parsing errors that happened, or a"]
+    #[doc = "[`Language`]"]
+    #[doc = r" instance containing the parsed structured data."]
     pub fn parse(
         input: &str,
-    ) -> core::result::Result<Language, Vec<rust_sitter::errors::ParseError>> {
-        let mut parser = rust_sitter::tree_sitter::Parser::new();
-        parser.set_language(language()).unwrap();
-        let tree = parser.parse(input, None).unwrap();
-        let root_node = tree.root_node();
-        if root_node.has_error() {
-            let mut errors = vec![];
-            rust_sitter::errors::collect_parsing_errors(&root_node, input.as_bytes(), &mut errors);
-            Err(errors)
-        } else {
-            use rust_sitter::Extract;
-            Ok(<Language as rust_sitter::Extract<_>>::extract(
-                Some(root_node),
-                input.as_bytes(),
-                0,
-                None,
-            ))
-        }
+    ) -> core::result::Result<Language, Vec<::rust_sitter::errors::ParseError>> {
+        ::rust_sitter::__private::parse::<Language>(input, language)
     }
 }
 

--- a/macro/src/snapshots/rust_sitter_macro__tests__struct_optional.snap
+++ b/macro/src/snapshots/rust_sitter_macro__tests__struct_optional.snap
@@ -24,46 +24,19 @@ mod grammar {
                 source: &[u8],
                 last_idx: &mut usize,
             ) -> Option<i32> {
-                if let Some(cursor) = cursor_opt.as_mut() {
-                    loop {
-                        let n = cursor.node();
-                        if let Some(name) = cursor.field_name() {
-                            if name == "v" {
-                                let node: Option<rust_sitter::tree_sitter::Node> = Some(n);
-                                let out =
-                                    <Option<rust_sitter::WithLeaf<i32>> as rust_sitter::Extract<
-                                        _,
-                                    >>::extract(
-                                        node,
-                                        source,
-                                        *last_idx,
-                                        Some(&|v| v.parse().unwrap()),
-                                    );
-                                if !cursor.goto_next_sibling() {
-                                    *cursor_opt = None;
-                                };
-                                *last_idx = n.end_byte();
-                                return out;
-                            } else {
-                                let node: Option<rust_sitter::tree_sitter::Node> = None;
-                                return < Option < rust_sitter :: WithLeaf < i32 > > as rust_sitter :: Extract < _ > > :: extract (node , source , * last_idx , Some (& | v | v . parse () . unwrap ())) ;
-                            }
-                        } else {
-                            *last_idx = n.end_byte();
-                        }
-                        if !cursor.goto_next_sibling() {
-                            let node: Option<rust_sitter::tree_sitter::Node> = None;
-                            return <Option<rust_sitter::WithLeaf<i32>> as rust_sitter::Extract<
-                                _,
-                            >>::extract(
-                                node, source, *last_idx, Some(&|v| v.parse().unwrap())
-                            );
-                        }
-                    }
-                } else {
-                    let node: Option<rust_sitter::tree_sitter::Node> = None;
-                    return < Option < rust_sitter :: WithLeaf < i32 > > as rust_sitter :: Extract < _ > > :: extract (node , source , * last_idx , Some (& | v | v . parse () . unwrap ())) ;
-                }
+                rust_sitter::__private::extract_field(
+                    cursor_opt,
+                    last_idx,
+                    "v",
+                    move |node, last_idx| {
+                        <Option<rust_sitter::WithLeaf<i32>> as rust_sitter::Extract<_>>::extract(
+                            node,
+                            source,
+                            *last_idx,
+                            Some(&|v| v.parse().unwrap()),
+                        )
+                    },
+                )
             }
             #[allow(non_snake_case)]
             #[allow(clippy::unused_unit)]
@@ -72,56 +45,25 @@ mod grammar {
                 source: &[u8],
                 last_idx: &mut usize,
             ) -> Option<Number> {
-                if let Some(cursor) = cursor_opt.as_mut() {
-                    loop {
-                        let n = cursor.node();
-                        if let Some(name) = cursor.field_name() {
-                            if name == "t" {
-                                let node: Option<rust_sitter::tree_sitter::Node> = Some(n);
-                                let out = <Option<Number> as rust_sitter::Extract<_>>::extract(
-                                    node, source, *last_idx, None,
-                                );
-                                if !cursor.goto_next_sibling() {
-                                    *cursor_opt = None;
-                                };
-                                *last_idx = n.end_byte();
-                                return out;
-                            } else {
-                                let node: Option<rust_sitter::tree_sitter::Node> = None;
-                                return <Option<Number> as rust_sitter::Extract<_>>::extract(
-                                    node, source, *last_idx, None,
-                                );
-                            }
-                        } else {
-                            *last_idx = n.end_byte();
-                        }
-                        if !cursor.goto_next_sibling() {
-                            let node: Option<rust_sitter::tree_sitter::Node> = None;
-                            return <Option<Number> as rust_sitter::Extract<_>>::extract(
-                                node, source, *last_idx, None,
-                            );
-                        }
-                    }
-                } else {
-                    let node: Option<rust_sitter::tree_sitter::Node> = None;
-                    return <Option<Number> as rust_sitter::Extract<_>>::extract(
-                        node, source, *last_idx, None,
-                    );
-                }
+                rust_sitter::__private::extract_field(
+                    cursor_opt,
+                    last_idx,
+                    "t",
+                    move |node, last_idx| {
+                        <Option<Number> as rust_sitter::Extract<_>>::extract(
+                            node, source, *last_idx, None,
+                        )
+                    },
+                )
             }
             #[allow(non_snake_case)]
             fn extract_Language(node: rust_sitter::tree_sitter::Node, source: &[u8]) -> Language {
-                let mut last_idx = node.start_byte();
-                let mut parent_cursor = node.walk();
-                let mut cursor = if parent_cursor.goto_first_child() {
-                    Some(parent_cursor)
-                } else {
-                    None
-                };
-                Language {
-                    v: extract_Language_v(&mut cursor, source, &mut last_idx),
-                    t: extract_Language_t(&mut cursor, source, &mut last_idx),
-                }
+                rust_sitter::__private::extract_struct_or_variant(node, move |cursor, last_idx| {
+                    Language {
+                        v: extract_Language_v(cursor, source, last_idx),
+                        t: extract_Language_t(cursor, source, last_idx),
+                    }
+                })
             }
             extract_Language(node, source)
         }
@@ -146,52 +88,27 @@ mod grammar {
                 source: &[u8],
                 last_idx: &mut usize,
             ) -> i32 {
-                if let Some(cursor) = cursor_opt.as_mut() {
-                    loop {
-                        let n = cursor.node();
-                        if let Some(name) = cursor.field_name() {
-                            if name == "v" {
-                                let node: Option<rust_sitter::tree_sitter::Node> = Some(n);
-                                let out = < rust_sitter :: WithLeaf < i32 > as rust_sitter :: Extract < _ > > :: extract (node , source , * last_idx , Some (& | v | v . parse () . unwrap ())) ;
-                                if !cursor.goto_next_sibling() {
-                                    *cursor_opt = None;
-                                };
-                                *last_idx = n.end_byte();
-                                return out;
-                            } else {
-                                let node: Option<rust_sitter::tree_sitter::Node> = None;
-                                return < rust_sitter :: WithLeaf < i32 > as rust_sitter :: Extract < _ > > :: extract (node , source , * last_idx , Some (& | v | v . parse () . unwrap ())) ;
-                            }
-                        } else {
-                            *last_idx = n.end_byte();
-                        }
-                        if !cursor.goto_next_sibling() {
-                            let node: Option<rust_sitter::tree_sitter::Node> = None;
-                            return < rust_sitter :: WithLeaf < i32 > as rust_sitter :: Extract < _ > > :: extract (node , source , * last_idx , Some (& | v | v . parse () . unwrap ())) ;
-                        }
-                    }
-                } else {
-                    let node: Option<rust_sitter::tree_sitter::Node> = None;
-                    return <rust_sitter::WithLeaf<i32> as rust_sitter::Extract<_>>::extract(
-                        node,
-                        source,
-                        *last_idx,
-                        Some(&|v| v.parse().unwrap()),
-                    );
-                }
+                rust_sitter::__private::extract_field(
+                    cursor_opt,
+                    last_idx,
+                    "v",
+                    move |node, last_idx| {
+                        <rust_sitter::WithLeaf<i32> as rust_sitter::Extract<_>>::extract(
+                            node,
+                            source,
+                            *last_idx,
+                            Some(&|v| v.parse().unwrap()),
+                        )
+                    },
+                )
             }
             #[allow(non_snake_case)]
             fn extract_Number(node: rust_sitter::tree_sitter::Node, source: &[u8]) -> Number {
-                let mut last_idx = node.start_byte();
-                let mut parent_cursor = node.walk();
-                let mut cursor = if parent_cursor.goto_first_child() {
-                    Some(parent_cursor)
-                } else {
-                    None
-                };
-                Number {
-                    v: extract_Number_v(&mut cursor, source, &mut last_idx),
-                }
+                rust_sitter::__private::extract_struct_or_variant(node, move |cursor, last_idx| {
+                    Number {
+                        v: extract_Number_v(cursor, source, last_idx),
+                    }
+                })
             }
             extract_Number(node, source)
         }

--- a/macro/src/snapshots/rust_sitter_macro__tests__struct_repeat.snap
+++ b/macro/src/snapshots/rust_sitter_macro__tests__struct_repeat.snap
@@ -23,58 +23,27 @@ mod grammar {
                 source: &[u8],
                 last_idx: &mut usize,
             ) -> Vec<Number> {
-                if let Some(cursor) = cursor_opt.as_mut() {
-                    loop {
-                        let n = cursor.node();
-                        if let Some(name) = cursor.field_name() {
-                            if name == "numbers" {
-                                let node: Option<rust_sitter::tree_sitter::Node> = Some(n);
-                                let out = <Vec<Number> as rust_sitter::Extract<_>>::extract(
-                                    node, source, *last_idx, None,
-                                );
-                                if !cursor.goto_next_sibling() {
-                                    *cursor_opt = None;
-                                };
-                                *last_idx = n.end_byte();
-                                return out;
-                            } else {
-                                let node: Option<rust_sitter::tree_sitter::Node> = None;
-                                return <Vec<Number> as rust_sitter::Extract<_>>::extract(
-                                    node, source, *last_idx, None,
-                                );
-                            }
-                        } else {
-                            *last_idx = n.end_byte();
-                        }
-                        if !cursor.goto_next_sibling() {
-                            let node: Option<rust_sitter::tree_sitter::Node> = None;
-                            return <Vec<Number> as rust_sitter::Extract<_>>::extract(
-                                node, source, *last_idx, None,
-                            );
-                        }
-                    }
-                } else {
-                    let node: Option<rust_sitter::tree_sitter::Node> = None;
-                    return <Vec<Number> as rust_sitter::Extract<_>>::extract(
-                        node, source, *last_idx, None,
-                    );
-                }
+                rust_sitter::__private::extract_field(
+                    cursor_opt,
+                    last_idx,
+                    "numbers",
+                    move |node, last_idx| {
+                        <Vec<Number> as rust_sitter::Extract<_>>::extract(
+                            node, source, *last_idx, None,
+                        )
+                    },
+                )
             }
             #[allow(non_snake_case)]
             fn extract_NumberList(
                 node: rust_sitter::tree_sitter::Node,
                 source: &[u8],
             ) -> NumberList {
-                let mut last_idx = node.start_byte();
-                let mut parent_cursor = node.walk();
-                let mut cursor = if parent_cursor.goto_first_child() {
-                    Some(parent_cursor)
-                } else {
-                    None
-                };
-                NumberList {
-                    numbers: extract_NumberList_numbers(&mut cursor, source, &mut last_idx),
-                }
+                rust_sitter::__private::extract_struct_or_variant(node, move |cursor, last_idx| {
+                    NumberList {
+                        numbers: extract_NumberList_numbers(cursor, source, last_idx),
+                    }
+                })
             }
             extract_NumberList(node, source)
         }
@@ -99,52 +68,27 @@ mod grammar {
                 source: &[u8],
                 last_idx: &mut usize,
             ) -> i32 {
-                if let Some(cursor) = cursor_opt.as_mut() {
-                    loop {
-                        let n = cursor.node();
-                        if let Some(name) = cursor.field_name() {
-                            if name == "v" {
-                                let node: Option<rust_sitter::tree_sitter::Node> = Some(n);
-                                let out = < rust_sitter :: WithLeaf < i32 > as rust_sitter :: Extract < _ > > :: extract (node , source , * last_idx , Some (& | v | v . parse () . unwrap ())) ;
-                                if !cursor.goto_next_sibling() {
-                                    *cursor_opt = None;
-                                };
-                                *last_idx = n.end_byte();
-                                return out;
-                            } else {
-                                let node: Option<rust_sitter::tree_sitter::Node> = None;
-                                return < rust_sitter :: WithLeaf < i32 > as rust_sitter :: Extract < _ > > :: extract (node , source , * last_idx , Some (& | v | v . parse () . unwrap ())) ;
-                            }
-                        } else {
-                            *last_idx = n.end_byte();
-                        }
-                        if !cursor.goto_next_sibling() {
-                            let node: Option<rust_sitter::tree_sitter::Node> = None;
-                            return < rust_sitter :: WithLeaf < i32 > as rust_sitter :: Extract < _ > > :: extract (node , source , * last_idx , Some (& | v | v . parse () . unwrap ())) ;
-                        }
-                    }
-                } else {
-                    let node: Option<rust_sitter::tree_sitter::Node> = None;
-                    return <rust_sitter::WithLeaf<i32> as rust_sitter::Extract<_>>::extract(
-                        node,
-                        source,
-                        *last_idx,
-                        Some(&|v| v.parse().unwrap()),
-                    );
-                }
+                rust_sitter::__private::extract_field(
+                    cursor_opt,
+                    last_idx,
+                    "v",
+                    move |node, last_idx| {
+                        <rust_sitter::WithLeaf<i32> as rust_sitter::Extract<_>>::extract(
+                            node,
+                            source,
+                            *last_idx,
+                            Some(&|v| v.parse().unwrap()),
+                        )
+                    },
+                )
             }
             #[allow(non_snake_case)]
             fn extract_Number(node: rust_sitter::tree_sitter::Node, source: &[u8]) -> Number {
-                let mut last_idx = node.start_byte();
-                let mut parent_cursor = node.walk();
-                let mut cursor = if parent_cursor.goto_first_child() {
-                    Some(parent_cursor)
-                } else {
-                    None
-                };
-                Number {
-                    v: extract_Number_v(&mut cursor, source, &mut last_idx),
-                }
+                rust_sitter::__private::extract_struct_or_variant(node, move |cursor, last_idx| {
+                    Number {
+                        v: extract_Number_v(cursor, source, last_idx),
+                    }
+                })
             }
             extract_Number(node, source)
         }
@@ -169,56 +113,25 @@ mod grammar {
                 source: &[u8],
                 last_idx: &mut usize,
             ) -> () {
-                if let Some(cursor) = cursor_opt.as_mut() {
-                    loop {
-                        let n = cursor.node();
-                        if let Some(name) = cursor.field_name() {
-                            if name == "_whitespace" {
-                                let node: Option<rust_sitter::tree_sitter::Node> = Some(n);
-                                let out = <() as rust_sitter::Extract<_>>::extract(
-                                    node, source, *last_idx, None,
-                                );
-                                if !cursor.goto_next_sibling() {
-                                    *cursor_opt = None;
-                                };
-                                *last_idx = n.end_byte();
-                                return out;
-                            } else {
-                                let node: Option<rust_sitter::tree_sitter::Node> = None;
-                                return <() as rust_sitter::Extract<_>>::extract(
-                                    node, source, *last_idx, None,
-                                );
-                            }
-                        } else {
-                            *last_idx = n.end_byte();
-                        }
-                        if !cursor.goto_next_sibling() {
-                            let node: Option<rust_sitter::tree_sitter::Node> = None;
-                            return <() as rust_sitter::Extract<_>>::extract(
-                                node, source, *last_idx, None,
-                            );
-                        }
-                    }
-                } else {
-                    let node: Option<rust_sitter::tree_sitter::Node> = None;
-                    return <() as rust_sitter::Extract<_>>::extract(node, source, *last_idx, None);
-                }
+                rust_sitter::__private::extract_field(
+                    cursor_opt,
+                    last_idx,
+                    "_whitespace",
+                    move |node, last_idx| {
+                        <() as rust_sitter::Extract<_>>::extract(node, source, *last_idx, None)
+                    },
+                )
             }
             #[allow(non_snake_case)]
             fn extract_Whitespace(
                 node: rust_sitter::tree_sitter::Node,
                 source: &[u8],
             ) -> Whitespace {
-                let mut last_idx = node.start_byte();
-                let mut parent_cursor = node.walk();
-                let mut cursor = if parent_cursor.goto_first_child() {
-                    Some(parent_cursor)
-                } else {
-                    None
-                };
-                Whitespace {
-                    _whitespace: extract_Whitespace__whitespace(&mut cursor, source, &mut last_idx),
-                }
+                rust_sitter::__private::extract_struct_or_variant(node, move |cursor, last_idx| {
+                    Whitespace {
+                        _whitespace: extract_Whitespace__whitespace(cursor, source, last_idx),
+                    }
+                })
             }
             extract_Whitespace(node, source)
         }

--- a/macro/src/snapshots/rust_sitter_macro__tests__struct_repeat.snap
+++ b/macro/src/snapshots/rust_sitter_macro__tests__struct_repeat.snap
@@ -1,167 +1,101 @@
 ---
 source: macro/src/lib.rs
-expression: "rustfmt_code(&expand_grammar(parse_quote! {\n                            #[rust_sitter :: grammar(\"test\")] mod grammar\n                            {\n                                #[rust_sitter :: language] pub struct NumberList\n                                { numbers : Vec < Number >, } pub struct Number\n                                {\n                                    #[rust_sitter ::\n                                    leaf(pattern = r\"\\d+\", transform = | v |\n                                    v.parse().unwrap())] v : i32\n                                } #[rust_sitter :: extra] struct Whitespace\n                                {\n                                    #[rust_sitter :: leaf(pattern = r\"\\s\")] _whitespace : (),\n                                }\n                            }\n                        }).to_token_stream().to_string())"
+expression: "rustfmt_code(&expand_grammar(parse_quote! {\n                                #[rust_sitter :: grammar(\"test\")] mod grammar\n                                {\n                                    #[rust_sitter :: language] pub struct NumberList\n                                    { numbers : Vec < Number >, } pub struct Number\n                                    {\n                                        #[rust_sitter ::\n                                        leaf(pattern = r\"\\d+\", transform = | v |\n                                        v.parse().unwrap())] v : i32\n                                    } #[rust_sitter :: extra] struct Whitespace\n                                    {\n                                        #[rust_sitter :: leaf(pattern = r\"\\s\")] _whitespace : (),\n                                    }\n                                }\n                            })?.to_token_stream().to_string())"
 ---
 mod grammar {
     pub struct NumberList {
         numbers: Vec<Number>,
     }
-    impl rust_sitter::Extract<NumberList> for NumberList {
+    impl ::rust_sitter::Extract<NumberList> for NumberList {
         type LeafFn = ();
         #[allow(non_snake_case)]
         fn extract(
-            node: Option<rust_sitter::tree_sitter::Node>,
+            node: Option<::rust_sitter::tree_sitter::Node>,
             source: &[u8],
             last_idx: usize,
             _leaf_fn: Option<&Self::LeafFn>,
         ) -> Self {
             let node = node.unwrap();
-            #[allow(non_snake_case)]
-            #[allow(clippy::unused_unit)]
-            fn extract_NumberList_numbers(
-                cursor_opt: &mut Option<rust_sitter::tree_sitter::TreeCursor>,
-                source: &[u8],
-                last_idx: &mut usize,
-            ) -> Vec<Number> {
-                rust_sitter::__private::extract_field(
-                    cursor_opt,
-                    last_idx,
-                    "numbers",
-                    move |node, last_idx| {
-                        <Vec<Number> as rust_sitter::Extract<_>>::extract(
-                            node, source, *last_idx, None,
+            ::rust_sitter::__private::extract_struct_or_variant(node, move |cursor, last_idx| {
+                NumberList {
+                    numbers: {
+                        ::rust_sitter::__private::extract_field::<Vec<Number>, _>(
+                            cursor, source, last_idx, "numbers", None,
                         )
                     },
-                )
-            }
-            #[allow(non_snake_case)]
-            fn extract_NumberList(
-                node: rust_sitter::tree_sitter::Node,
-                source: &[u8],
-            ) -> NumberList {
-                rust_sitter::__private::extract_struct_or_variant(node, move |cursor, last_idx| {
-                    NumberList {
-                        numbers: extract_NumberList_numbers(cursor, source, last_idx),
-                    }
-                })
-            }
-            extract_NumberList(node, source)
+                }
+            })
         }
     }
     pub struct Number {
         v: i32,
     }
-    impl rust_sitter::Extract<Number> for Number {
+    impl ::rust_sitter::Extract<Number> for Number {
         type LeafFn = ();
         #[allow(non_snake_case)]
         fn extract(
-            node: Option<rust_sitter::tree_sitter::Node>,
+            node: Option<::rust_sitter::tree_sitter::Node>,
             source: &[u8],
             last_idx: usize,
             _leaf_fn: Option<&Self::LeafFn>,
         ) -> Self {
             let node = node.unwrap();
-            #[allow(non_snake_case)]
-            #[allow(clippy::unused_unit)]
-            fn extract_Number_v(
-                cursor_opt: &mut Option<rust_sitter::tree_sitter::TreeCursor>,
-                source: &[u8],
-                last_idx: &mut usize,
-            ) -> i32 {
-                rust_sitter::__private::extract_field(
-                    cursor_opt,
-                    last_idx,
-                    "v",
-                    move |node, last_idx| {
-                        <rust_sitter::WithLeaf<i32> as rust_sitter::Extract<_>>::extract(
-                            node,
+            ::rust_sitter::__private::extract_struct_or_variant(node, move |cursor, last_idx| {
+                Number {
+                    v: {
+                        ::rust_sitter::__private::extract_field::<rust_sitter::WithLeaf<i32>, _>(
+                            cursor,
                             source,
-                            *last_idx,
+                            last_idx,
+                            "v",
                             Some(&|v| v.parse().unwrap()),
                         )
                     },
-                )
-            }
-            #[allow(non_snake_case)]
-            fn extract_Number(node: rust_sitter::tree_sitter::Node, source: &[u8]) -> Number {
-                rust_sitter::__private::extract_struct_or_variant(node, move |cursor, last_idx| {
-                    Number {
-                        v: extract_Number_v(cursor, source, last_idx),
-                    }
-                })
-            }
-            extract_Number(node, source)
+                }
+            })
         }
     }
     struct Whitespace {
         _whitespace: (),
     }
-    impl rust_sitter::Extract<Whitespace> for Whitespace {
+    impl ::rust_sitter::Extract<Whitespace> for Whitespace {
         type LeafFn = ();
         #[allow(non_snake_case)]
         fn extract(
-            node: Option<rust_sitter::tree_sitter::Node>,
+            node: Option<::rust_sitter::tree_sitter::Node>,
             source: &[u8],
             last_idx: usize,
             _leaf_fn: Option<&Self::LeafFn>,
         ) -> Self {
             let node = node.unwrap();
-            #[allow(non_snake_case)]
-            #[allow(clippy::unused_unit)]
-            fn extract_Whitespace__whitespace(
-                cursor_opt: &mut Option<rust_sitter::tree_sitter::TreeCursor>,
-                source: &[u8],
-                last_idx: &mut usize,
-            ) -> () {
-                rust_sitter::__private::extract_field(
-                    cursor_opt,
-                    last_idx,
-                    "_whitespace",
-                    move |node, last_idx| {
-                        <() as rust_sitter::Extract<_>>::extract(node, source, *last_idx, None)
+            ::rust_sitter::__private::extract_struct_or_variant(node, move |cursor, last_idx| {
+                Whitespace {
+                    _whitespace: {
+                        ::rust_sitter::__private::extract_field::<(), _>(
+                            cursor,
+                            source,
+                            last_idx,
+                            "_whitespace",
+                            None,
+                        )
                     },
-                )
-            }
-            #[allow(non_snake_case)]
-            fn extract_Whitespace(
-                node: rust_sitter::tree_sitter::Node,
-                source: &[u8],
-            ) -> Whitespace {
-                rust_sitter::__private::extract_struct_or_variant(node, move |cursor, last_idx| {
-                    Whitespace {
-                        _whitespace: extract_Whitespace__whitespace(cursor, source, last_idx),
-                    }
-                })
-            }
-            extract_Whitespace(node, source)
+                }
+            })
         }
     }
     extern "C" {
-        fn tree_sitter_test() -> rust_sitter::tree_sitter::Language;
+        fn tree_sitter_test() -> ::rust_sitter::tree_sitter::Language;
     }
-    pub fn language() -> rust_sitter::tree_sitter::Language {
+    pub fn language() -> ::rust_sitter::tree_sitter::Language {
         unsafe { tree_sitter_test() }
     }
+    #[doc = r" Parse an input string according to the grammar. Returns either any parsing errors that happened, or a"]
+    #[doc = "[`NumberList`]"]
+    #[doc = r" instance containing the parsed structured data."]
     pub fn parse(
         input: &str,
-    ) -> core::result::Result<NumberList, Vec<rust_sitter::errors::ParseError>> {
-        let mut parser = rust_sitter::tree_sitter::Parser::new();
-        parser.set_language(language()).unwrap();
-        let tree = parser.parse(input, None).unwrap();
-        let root_node = tree.root_node();
-        if root_node.has_error() {
-            let mut errors = vec![];
-            rust_sitter::errors::collect_parsing_errors(&root_node, input.as_bytes(), &mut errors);
-            Err(errors)
-        } else {
-            use rust_sitter::Extract;
-            Ok(<NumberList as rust_sitter::Extract<_>>::extract(
-                Some(root_node),
-                input.as_bytes(),
-                0,
-                None,
-            ))
-        }
+    ) -> core::result::Result<NumberList, Vec<::rust_sitter::errors::ParseError>> {
+        ::rust_sitter::__private::parse::<NumberList>(input, language)
     }
 }
 

--- a/runtime/src/__private.rs
+++ b/runtime/src/__private.rs
@@ -53,6 +53,6 @@ pub fn extract_field<T>(
             }
         }
     } else {
-        return leaf_expr(None, last_idx);
+        leaf_expr(None, last_idx)
     }
 }

--- a/runtime/src/__private.rs
+++ b/runtime/src/__private.rs
@@ -1,0 +1,48 @@
+//! # DO NOT USE THIS MODULE!
+//! 
+//! This module contains functions for use in the expanded macros produced by rust-sitter.
+//! They need to be public so they can be accessed at all (\*cough\* macro hygiene), but
+//! they are not intended to actually be called in any other circumstance.
+
+use crate::tree_sitter;
+
+pub fn extract_struct_or_variant<T>(node: tree_sitter::Node, construct_expr: impl Fn(&mut Option<tree_sitter::TreeCursor>, &mut usize) -> T) -> T {
+    let mut parent_cursor = node.walk();
+    construct_expr(&mut if parent_cursor.goto_first_child() {
+        Some(parent_cursor)
+    } else {
+        None
+    }, &mut node.start_byte())
+}
+
+pub fn extract_field<T>(cursor_opt: &mut Option<tree_sitter::TreeCursor>, last_idx: &mut usize, field_name: &str, leaf_expr: impl Fn(Option<tree_sitter::Node>, &mut usize) -> T) -> T {
+
+    if let Some(cursor) = cursor_opt.as_mut() {
+        loop {
+            let n = cursor.node();
+            if let Some(name) = cursor.field_name() {
+                if name == field_name {
+                    let out = leaf_expr(Some(n), last_idx);
+
+                    if !cursor.goto_next_sibling() {
+                        *cursor_opt = None;
+                    };
+
+                    *last_idx = n.end_byte();
+
+                    return out;
+                } else {
+                    return leaf_expr(None, last_idx);
+                }
+            } else {
+                *last_idx = n.end_byte();
+            }
+
+            if !cursor.goto_next_sibling() {
+                return leaf_expr(None, last_idx);
+            }
+        }
+    } else {
+        return leaf_expr(None, last_idx);
+    }
+}

--- a/runtime/src/__private.rs
+++ b/runtime/src/__private.rs
@@ -1,22 +1,32 @@
 //! # DO NOT USE THIS MODULE!
-//! 
+//!
 //! This module contains functions for use in the expanded macros produced by rust-sitter.
 //! They need to be public so they can be accessed at all (\*cough\* macro hygiene), but
 //! they are not intended to actually be called in any other circumstance.
 
 use crate::tree_sitter;
 
-pub fn extract_struct_or_variant<T>(node: tree_sitter::Node, construct_expr: impl Fn(&mut Option<tree_sitter::TreeCursor>, &mut usize) -> T) -> T {
+pub fn extract_struct_or_variant<T>(
+    node: tree_sitter::Node,
+    construct_expr: impl Fn(&mut Option<tree_sitter::TreeCursor>, &mut usize) -> T,
+) -> T {
     let mut parent_cursor = node.walk();
-    construct_expr(&mut if parent_cursor.goto_first_child() {
-        Some(parent_cursor)
-    } else {
-        None
-    }, &mut node.start_byte())
+    construct_expr(
+        &mut if parent_cursor.goto_first_child() {
+            Some(parent_cursor)
+        } else {
+            None
+        },
+        &mut node.start_byte(),
+    )
 }
 
-pub fn extract_field<T>(cursor_opt: &mut Option<tree_sitter::TreeCursor>, last_idx: &mut usize, field_name: &str, leaf_expr: impl Fn(Option<tree_sitter::Node>, &mut usize) -> T) -> T {
-
+pub fn extract_field<T>(
+    cursor_opt: &mut Option<tree_sitter::TreeCursor>,
+    last_idx: &mut usize,
+    field_name: &str,
+    leaf_expr: impl Fn(Option<tree_sitter::Node>, &mut usize) -> T,
+) -> T {
     if let Some(cursor) = cursor_opt.as_mut() {
         loop {
             let n = cursor.node();

--- a/runtime/src/__private.rs
+++ b/runtime/src/__private.rs
@@ -4,7 +4,7 @@
 //! They need to be public so they can be accessed at all (\*cough\* macro hygiene), but
 //! they are not intended to actually be called in any other circumstance.
 
-use crate::tree_sitter;
+use crate::{tree_sitter, Extract};
 
 pub fn extract_struct_or_variant<T>(
     node: tree_sitter::Node,
@@ -21,18 +21,19 @@ pub fn extract_struct_or_variant<T>(
     )
 }
 
-pub fn extract_field<T>(
+pub fn extract_field<LT: Extract<T>, T>(
     cursor_opt: &mut Option<tree_sitter::TreeCursor>,
+    source: &[u8],
     last_idx: &mut usize,
     field_name: &str,
-    leaf_expr: impl Fn(Option<tree_sitter::Node>, &mut usize) -> T,
+    closure_ref: Option<&LT::LeafFn>,
 ) -> T {
     if let Some(cursor) = cursor_opt.as_mut() {
         loop {
             let n = cursor.node();
             if let Some(name) = cursor.field_name() {
                 if name == field_name {
-                    let out = leaf_expr(Some(n), last_idx);
+                    let out = LT::extract(Some(n), source, *last_idx, closure_ref);
 
                     if !cursor.goto_next_sibling() {
                         *cursor_opt = None;
@@ -42,17 +43,41 @@ pub fn extract_field<T>(
 
                     return out;
                 } else {
-                    return leaf_expr(None, last_idx);
+                    return LT::extract(None, source, *last_idx, closure_ref);
                 }
             } else {
                 *last_idx = n.end_byte();
             }
 
             if !cursor.goto_next_sibling() {
-                return leaf_expr(None, last_idx);
+                return LT::extract(None, source, *last_idx, closure_ref);
             }
         }
     } else {
-        leaf_expr(None, last_idx)
+        LT::extract(None, source, *last_idx, closure_ref)
+    }
+}
+
+pub fn parse<T: Extract<T>>(
+    input: &str,
+    language: impl Fn() -> tree_sitter::Language,
+) -> core::result::Result<T, Vec<crate::errors::ParseError>> {
+    let mut parser = crate::tree_sitter::Parser::new();
+    parser.set_language(language()).unwrap();
+    let tree = parser.parse(input, None).unwrap();
+    let root_node = tree.root_node();
+
+    if root_node.has_error() {
+        let mut errors = vec![];
+        crate::errors::collect_parsing_errors(&root_node, input.as_bytes(), &mut errors);
+
+        Err(errors)
+    } else {
+        Ok(<T as crate::Extract<_>>::extract(
+            Some(root_node),
+            input.as_bytes(),
+            0,
+            None,
+        ))
     }
 }

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -219,3 +219,44 @@ pub mod errors {
         }
     }
 }
+
+pub fn extract_struct_or_variant<T>(node: tree_sitter::Node, construct_expr: impl Fn(&mut Option<tree_sitter::TreeCursor>, &mut usize) -> T) -> T {
+    let mut parent_cursor = node.walk();
+    construct_expr(&mut if parent_cursor.goto_first_child() {
+        Some(parent_cursor)
+    } else {
+        None
+    }, &mut node.start_byte())
+}
+
+pub fn extract_field<T>(cursor_opt: &mut Option<tree_sitter::TreeCursor>, last_idx: &mut usize, field_name: &str, leaf_expr: impl Fn(Option<tree_sitter::Node>, &mut usize) -> T) -> T {
+
+    if let Some(cursor) = cursor_opt.as_mut() {
+        loop {
+            let n = cursor.node();
+            if let Some(name) = cursor.field_name() {
+                if name == field_name {
+                    let out = leaf_expr(Some(n), last_idx);
+
+                    if !cursor.goto_next_sibling() {
+                        *cursor_opt = None;
+                    };
+
+                    *last_idx = n.end_byte();
+
+                    return out;
+                } else {
+                    return leaf_expr(None, last_idx);
+                }
+            } else {
+                *last_idx = n.end_byte();
+            }
+
+            if !cursor.goto_next_sibling() {
+                return leaf_expr(None, last_idx);
+            }
+        }
+    } else {
+        return leaf_expr(None, last_idx);
+    }
+}

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -1,3 +1,5 @@
+pub mod __private;
+
 use std::ops::Deref;
 
 pub use rust_sitter_macro::*;
@@ -217,46 +219,5 @@ pub mod errors {
             node.children(&mut cursor)
                 .for_each(|c| collect_parsing_errors(&c, source, errors));
         }
-    }
-}
-
-pub fn extract_struct_or_variant<T>(node: tree_sitter::Node, construct_expr: impl Fn(&mut Option<tree_sitter::TreeCursor>, &mut usize) -> T) -> T {
-    let mut parent_cursor = node.walk();
-    construct_expr(&mut if parent_cursor.goto_first_child() {
-        Some(parent_cursor)
-    } else {
-        None
-    }, &mut node.start_byte())
-}
-
-pub fn extract_field<T>(cursor_opt: &mut Option<tree_sitter::TreeCursor>, last_idx: &mut usize, field_name: &str, leaf_expr: impl Fn(Option<tree_sitter::Node>, &mut usize) -> T) -> T {
-
-    if let Some(cursor) = cursor_opt.as_mut() {
-        loop {
-            let n = cursor.node();
-            if let Some(name) = cursor.field_name() {
-                if name == field_name {
-                    let out = leaf_expr(Some(n), last_idx);
-
-                    if !cursor.goto_next_sibling() {
-                        *cursor_opt = None;
-                    };
-
-                    *last_idx = n.end_byte();
-
-                    return out;
-                } else {
-                    return leaf_expr(None, last_idx);
-                }
-            } else {
-                *last_idx = n.end_byte();
-            }
-
-            if !cursor.goto_next_sibling() {
-                return leaf_expr(None, last_idx);
-            }
-        }
-    } else {
-        return leaf_expr(None, last_idx);
     }
 }


### PR DESCRIPTION
Did some super basic work on this. Could still be improved a lot, by not generating a function for each field or enum variant, but that'd require more structural changes.

Might want to move these functions into a "pseudo-private" package, so the user doesn't accidentally call them.