### PR TITLE
Output relevant grammar files to the build directory if requested

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -497,9 +497,9 @@ checksum = "478c572c3d73181ff3c2539045f6eb99e5491218eae919370993b890cdbdd98e"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.49"
+version = "1.0.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57a8eca9f9c4ffde41714334dee777596264c7825420f521abc92b5b5deb63a5"
+checksum = "3d433d9f1a3e8c1263d9456598b16fec66f4acc9a74dacffd35c7bb09b3a1328"
 dependencies = [
  "unicode-ident",
 ]

--- a/macro/Cargo.toml
+++ b/macro/Cargo.toml
@@ -17,7 +17,7 @@ path = "src/lib.rs"
 [dependencies]
 syn = { version = "1.0", features = [ "full", "extra-traits" ] }
 quote = "1.0"
-proc-macro2 = "1.0.27"
+proc-macro2 = "1.0.67"
 rust-sitter-common = { version= "0.3.4", path = "../common" }
 
 [dev-dependencies]

--- a/tool/src/lib.rs
+++ b/tool/src/lib.rs
@@ -48,7 +48,11 @@ pub fn build_parsers(root_file: &Path) {
     generate_grammars(root_file).iter().for_each(|grammar| {
         let (grammar_name, grammar_c) =
             generate::generate_parser_for_grammar(&grammar.to_string()).unwrap();
-        
+        let tempfile = tempfile::Builder::new()
+            .prefix("grammar")
+            .tempdir()
+            .unwrap();
+
         let dir = if emit_artifacts {
             let grammar_dir = Path::new(out_dir.as_str()).join(format!("grammar_{grammar_name}",));
             std::fs::remove_dir_all(&grammar_dir).expect("Couldn't clear old artifacts");
@@ -58,10 +62,7 @@ pub fn build_parsers(root_file: &Path) {
                 .expect("Couldn't create grammar JSON directory");
             grammar_dir
         } else {
-            tempfile::Builder::new()
-            .prefix("grammar")
-            .tempdir()
-            .unwrap().path().into()
+            tempfile.path().into()
         };
 
         let grammar_file = dir.join("parser.c");
@@ -117,10 +118,10 @@ pub fn build_parsers(root_file: &Path) {
         let mut c_config = cc::Build::new();
         c_config.include(&dir).include(&sysroot_dir);
         c_config
-            // .flag_if_supported("-Wno-unused-label")
-            // .flag_if_supported("-Wno-unused-parameter")
-            // .flag_if_supported("-Wno-unused-but-set-variable")
-            // .flag_if_supported("-Wno-trigraphs")
+            .flag_if_supported("-Wno-unused-label")
+            .flag_if_supported("-Wno-unused-parameter")
+            .flag_if_supported("-Wno-unused-but-set-variable")
+            .flag_if_supported("-Wno-trigraphs")
             .flag_if_supported("-Wno-everything");
         c_config.file(dir.join("parser.c"));
 

--- a/tool/src/lib.rs
+++ b/tool/src/lib.rs
@@ -44,7 +44,9 @@ use tree_sitter_cli::generate;
 pub fn build_parsers(root_file: &Path) {
     use std::env;
     let out_dir = env::var("OUT_DIR").unwrap();
-    let emit_artifacts: bool = env::var("RUST_SITTER_EMIT_ARTIFACTS").map(|s| s.parse().unwrap_or(false)).unwrap_or(false);
+    let emit_artifacts: bool = env::var("RUST_SITTER_EMIT_ARTIFACTS")
+        .map(|s| s.parse().unwrap_or(false))
+        .unwrap_or(false);
     generate_grammars(root_file).iter().for_each(|grammar| {
         let (grammar_name, grammar_c) =
             generate::generate_parser_for_grammar(&grammar.to_string()).unwrap();


### PR DESCRIPTION
For my own tinkering with things like the external scanners, this has been a really helpful feature. Right now I've implemented it so it activates when the environment variable `RUST_SITTER_EMIT_ARTIFACTS` is set to truthy, because I didn't want to make a breaking change to the tool API. But if a breaking change was allowed, maybe the user could even select their own output directory for convenience.

Sorry for putting up so much random stuff all at once by the way. A lot of things have accumulated, and I'm finally learning how to sort through all that.