### PR TITLE
Add some implementations for Spanned

### DIFF
--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -1,6 +1,6 @@
 pub mod __private;
 
-use std::ops::Deref;
+use std::ops::{Deref, Index, IndexMut};
 
 pub use rust_sitter_macro::*;
 
@@ -108,7 +108,7 @@ impl<T: Extract<U>, U> Extract<Vec<U>> for Vec<T> {
     }
 }
 
-#[derive(Clone, Debug)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 /// A wrapper around a value that also contains the span of the value in the source.
 pub struct Spanned<T> {
     /// The underlying parsed node.
@@ -140,6 +140,20 @@ impl<T: Extract<U>, U> Extract<Spanned<U>> for Spanned<T> {
                 .map(|n| (n.start_byte(), n.end_byte()))
                 .unwrap_or((last_idx, last_idx)),
         }
+    }
+}
+
+impl<T> Index<Spanned<T>> for str {
+    type Output = str;
+
+    fn index(&self, index: Spanned<T>) -> &Self::Output {
+        &self[index.span.0..index.span.1]
+    }
+}
+
+impl<T> IndexMut<Spanned<T>> for str {
+    fn index_mut(&mut self, index: Spanned<T>) -> &mut Self::Output {
+        &mut self[index.span.0..index.span.1]
     }
 }
 


### PR DESCRIPTION
There's no reason that I can see why `Spanned` shouldn't implement all of the standard data traits, as well as be able to be used to index into source code.