### PR TITLE
fix: force using c11 as the upstream

### DIFF
--- a/tool/src/lib.rs
+++ b/tool/src/lib.rs
@@ -120,7 +120,7 @@ pub fn build_parsers(root_file: &Path) {
         }
 
         let mut c_config = cc::Build::new();
-        c_config.include(&dir).include(&sysroot_dir);
+        c_config.std("c11").include(&dir).include(&sysroot_dir);
         c_config
             .flag_if_supported("-Wno-unused-label")
             .flag_if_supported("-Wno-unused-parameter")


### PR DESCRIPTION
this patch fix compile rust nighty error by forcing the `CFLAG` to c11

reason:

- hydro depend on [rust-sitter](https://github.com/hydro-project/rust-sitter)
- and rust-sitter is depending on [tree-sitter](https://github.com/tree-sitter/tree-sitter)
- the error is from https://github.com/tree-sitter/tree-sitter/blob/b1d2b7cfb807410871a3679ee36e412ed2451d72/lib/src/parser.h#L201 using c99 upper
- but the rust-sitter build the parser.c  https://github.com/hydro-project/rust-sitter/blob/6f7b1ec5c495a4607ae33deea411efb397df3ac8/tool/src/lib.rs#L122 and did not using the c99 or c11 upper


greptimedb issue https://github.com/GreptimeTeam/greptimedb/pull/6046
more: https://github.com/airbus-cert/tree-sitter-powershell/pull/15
